### PR TITLE
Refactor Repo2Docker.fetch method to not need be passed its own members as arguments

### DIFF
--- a/repo2docker/app.py
+++ b/repo2docker/app.py
@@ -164,11 +164,16 @@ class Repo2Docker(Application):
         """
     )
 
-    def fetch(self, url, ref, checkout_path):
-        """Check out a repo using url and ref to the checkout_path location"""
+    def fetch(self, checkout_path, url=None, ref=None):
+        """Check out a repository using its url and ref to the checkout_path
+        location"""
+        if url is None:
+            url = self.repo
+        if ref is None:
+            ref = self.ref
         try:
-            for line in execute_cmd(['git', 'clone', '--recursive', url, checkout_path],
-                                    capture=self.json_logs):
+            for line in execute_cmd(['git', 'clone', '--recursive', url,
+                                     checkout_path], capture=self.json_logs):
                 self.log.info(line, extra=dict(phase='fetching'))
         except subprocess.CalledProcessError:
             self.log.error('Failed to clone repository!',
@@ -642,7 +647,7 @@ class Repo2Docker(Application):
         # cleanup if things go wrong
         with maybe_cleanup(checkout_path, self.cleanup_checkout):
             if self.repo_type == 'remote':
-                self.fetch(self.repo, self.ref, checkout_path)
+                self.fetch(checkout_path)
 
             os.chdir(checkout_path)
 


### PR DESCRIPTION
This is a tiny clean-up: Since `fetch()` is only called inside the
class, and two of the three arguments in that call are attributes of
`self`, there is no need to pass them as extra arguments.

To not break the API, the parameters in the method definition are now
set to a default of `None`; if these are used with their default,
they'll be set to the respective `self` attributes. Note that this
breaks behaviour where the `self` attribute is not `None`,
but `None` is explicitly passed for the respective parameter.