### PR TITLE
Add `--reuse-image` to not rebuild an image but instead re-populate content after r2d starts the container

### DIFF
--- a/repo2docker/__main__.py
+++ b/repo2docker/__main__.py
@@ -91,16 +91,18 @@ def get_argparser():
     )
 
     argparser.add_argument(
-        '--reuse-image',
-        dest='reuse_image',
-        action='store_true',
-        help=('Runs a container with refreshed repo contents without '
-                'building a new image if one exists.')
+        "--reuse-image",
+        dest="reuse_image",
+        action="store_true",
+        help=(
+            "Runs a container with refreshed repo contents without "
+            "building a new image if one exists."
+        ),
     )
 
     argparser.add_argument(
-        '--build-memory-limit',
-        help='Total Memory that can be used by the docker build process'
+        "--build-memory-limit",
+        help="Total Memory that can be used by the docker build process",
     )
 
     argparser.add_argument(

--- a/repo2docker/__main__.py
+++ b/repo2docker/__main__.py
@@ -91,10 +91,11 @@ def get_argparser():
     )
 
     argparser.add_argument(
-        '--run-changes',
-        dest='run_changes',
+        '--reuse-image',
+        dest='reuse_image',
         action='store_true',
-        help=('Run image for updated repo without rebuilding')
+        help=('Runs a container with refreshed repo contents without '
+                'building a new image if one exists.')
     )
 
     argparser.add_argument(
@@ -256,14 +257,18 @@ def make_r2d(argv=None):
 
     r2d.dry_run = not args.build
 
-    r2d.run_changes = args.run_changes
+    r2d.reuse_image = args.reuse_image
 
     if r2d.dry_run:
         # Can't push nor run if we aren't building
         args.run = False
         args.push = False
+        args.reuse_image = False
 
     r2d.run = args.run
+    if not r2d.run:
+        args.reuse_image = False
+
     r2d.push = args.push
 
     # check against r2d.run and not args.run as r2d.run is false on

--- a/repo2docker/__main__.py
+++ b/repo2docker/__main__.py
@@ -91,8 +91,15 @@ def get_argparser():
     )
 
     argparser.add_argument(
-        "--build-memory-limit",
-        help="Total Memory that can be used by the docker build process",
+        '--run-changes',
+        dest='run_changes',
+        action='store_true',
+        help=('Run image for updated repo without rebuilding')
+    )
+
+    argparser.add_argument(
+        '--build-memory-limit',
+        help='Total Memory that can be used by the docker build process'
     )
 
     argparser.add_argument(
@@ -248,6 +255,8 @@ def make_r2d(argv=None):
     r2d.json_logs = args.json_logs
 
     r2d.dry_run = not args.build
+
+    r2d.run_changes = args.run_changes
 
     if r2d.dry_run:
         # Can't push nor run if we aren't building

--- a/repo2docker/app.py
+++ b/repo2docker/app.py
@@ -313,13 +313,12 @@ class Repo2Docker(Application):
         config=True,
     )
 
-
     reuse_image = Bool(
         False,
         help="""
         Copies new contents to existing image.
         """,
-        config=True
+        config=True,
     )
 
     # FIXME: Refactor classes to separate build & run steps
@@ -554,7 +553,6 @@ class Repo2Docker(Application):
         # store ports on self so they can be retrieved in tests
         self.ports = ports
 
-
         container_volumes = {}
         if self.volumes:
             api_client = docker.APIClient(
@@ -575,7 +573,7 @@ class Repo2Docker(Application):
             detach=True,
             command=run_cmd,
             volumes=container_volumes,
-            environment=self.environment
+            environment=self.environment,
         )
 
         run_kwargs.update(self.extra_run_kwargs)
@@ -600,8 +598,7 @@ class Repo2Docker(Application):
                 self.log.error("Failed to copy repo contents into containe")
                 return container
 
-
-        while container.status == 'created':
+        while container.status == "created":
             time.sleep(0.5)
             container.reload()
 
@@ -644,13 +641,13 @@ class Repo2Docker(Application):
         if self.dry_run:
             return False
         # check if we already have an image for this content
-        client = docker.APIClient(version='auto', **kwargs_from_env())
+        client = docker.APIClient(version="auto", **kwargs_from_env())
         # looking for partial match without commit tag
         repo_image_name = self.output_image_spec[:-7]
 
         for image in client.images():
-            if image['RepoTags'] is not None:
-                for tag in image['RepoTags']:
+            if image["RepoTags"] is not None:
+                for tag in image["RepoTags"]:
 
                     if allow_revision and repo_image_name in tag:
                         self.output_image_spec = tag
@@ -686,7 +683,7 @@ class Repo2Docker(Application):
         else:
             if self.git_workdir is None:
 
-                checkout_path = tempfile.mkdtemp(prefix='repo2docker')
+                checkout_path = tempfile.mkdtemp(prefix="repo2docker")
                 self.git_workdir = checkout_path
             else:
                 checkout_path = self.git_workdir
@@ -700,8 +697,10 @@ class Repo2Docker(Application):
                 self.cleanup_checkout = False
 
             if self.find_image(revision):
-                self.log.info("Reusing existing image ({}), not "
-                              "building.".format(self.output_image_spec))
+                self.log.info(
+                    "Reusing existing image ({}), not "
+                    "building.".format(self.output_image_spec)
+                )
                 # no need to build, so skip to the end by `return`ing here
                 # this will still execute the finally clause and let's us
                 # avoid having to indent the build code by an extra level
@@ -780,7 +779,6 @@ class Repo2Docker(Application):
             # Cleanup checkout if necessary
             if self.cleanup_checkout:
                 shutil.rmtree(checkout_path, ignore_errors=True)
-
 
     def start(self):
         self.build()

--- a/repo2docker/app.py
+++ b/repo2docker/app.py
@@ -595,7 +595,6 @@ class Repo2Docker(Application):
             container.exec_run(cmd, stderr=True, stdout=True)
 
             copied = container.put_archive(image_workdir, repo_archive)
-            print("AM I GONE?!! {}".format(self.git_workdir))
             shutil.rmtree(self.git_workdir, ignore_errors=True)
             if not copied:
                 self.log.error("Failed to copy repo contents into containe")

--- a/repo2docker/app.py
+++ b/repo2docker/app.py
@@ -595,7 +595,7 @@ class Repo2Docker(Application):
             copied = container.put_archive(image_workdir, repo_archive)
             shutil.rmtree(self.git_workdir, ignore_errors=True)
             if not copied:
-                self.log.error("Failed to copy repo contents into containe")
+                self.log.error("Failed to copy repo contents into container")
                 return container
 
         while container.status == "created":

--- a/repo2docker/app.py
+++ b/repo2docker/app.py
@@ -314,7 +314,6 @@ class Repo2Docker(Application):
     )
 
 
-    # FIXME: update help msg
     reuse_image = Bool(
         False,
         help="""
@@ -596,6 +595,8 @@ class Repo2Docker(Application):
             container.exec_run(cmd, stderr=True, stdout=True)
 
             copied = container.put_archive(image_workdir, repo_archive)
+            print("AM I GONE?!! {}".format(self.git_workdir))
+            shutil.rmtree(self.git_workdir, ignore_errors=True)
             if not copied:
                 self.log.error("Failed to copy repo contents into containe")
                 return container
@@ -695,6 +696,10 @@ class Repo2Docker(Application):
             self.fetch(self.repo, self.ref, checkout_path)
 
             revision = self.reuse_image
+            if revision:
+                # repo contents will be cleaned up in run phase
+                self.cleanup_checkout = False
+
             if self.find_image(revision):
                 self.log.info("Reusing existing image ({}), not "
                               "building.".format(self.output_image_spec))
@@ -776,7 +781,7 @@ class Repo2Docker(Application):
             # Cleanup checkout if necessary
             if self.cleanup_checkout:
                 shutil.rmtree(checkout_path, ignore_errors=True)
-        return
+
 
     def start(self):
         self.build()

--- a/repo2docker/utils.py
+++ b/repo2docker/utils.py
@@ -4,6 +4,8 @@ import os
 import re
 import subprocess
 import chardet
+import tempfile
+import tarfile
 
 from shutil import copystat, copy2
 
@@ -479,3 +481,17 @@ def is_local_pip_requirement(line):
         # references a local file
         return True
     return False
+
+
+# copied from:
+# https://github.com/docker/docker-py/blob/master/tests/helpers.py#L29-L38
+def archive_repo(path):
+    f = tempfile.NamedTemporaryFile()
+    t = tarfile.open(mode="w", fileobj=f)
+
+    abs_path = os.path.abspath(path)
+    t.add(abs_path, arcname=os.path.basename(path), recursive=True)
+
+    t.close()
+    f.seek(0)
+    return f

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -39,6 +39,34 @@ def test_dont_find_image():
         instance.images.assert_called_with()
 
 
+def test_find_repo_image():
+    images = [{"RepoTags": ["some-org/some-repoSomeHash:latest"]}]
+
+    with patch("repo2docker.app.docker.APIClient") as FakeDockerClient:
+        instance = FakeDockerClient.return_value
+        instance.images.return_value = images
+
+        r2d = Repo2Docker()
+        r2d.output_image_spec = "some-org/some-repo"
+        assert r2d.find_repo_image()
+
+        instance.images.assert_called_with()
+
+
+def test_dont_find_repo_image():
+    images = [{"RepoTags": ["some-org/some-image-name:latest"]}]
+
+    with patch("repo2docker.app.docker.APIClient") as FakeDockerClient:
+        instance = FakeDockerClient.return_value
+        instance.images.return_value = images
+
+        r2d = Repo2Docker()
+        r2d.output_image_spec = "some-org/some-other-image-name"
+        assert not r2d.find_repo_image()
+
+        instance.images.assert_called_with()
+
+
 def test_image_name_remains_unchanged():
     # if we specify an image name, it should remain unmodified
     with TemporaryDirectory() as src:

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -39,7 +39,7 @@ def test_dont_find_image():
         instance.images.assert_called_with()
 
 
-def test_find_repo_image():
+def test_find_image_revision():
     images = [{"RepoTags": ["some-org/some-repoSomeHash:latest"]}]
 
     with patch("repo2docker.app.docker.APIClient") as FakeDockerClient:
@@ -48,12 +48,13 @@ def test_find_repo_image():
 
         r2d = Repo2Docker()
         r2d.output_image_spec = "some-org/some-repo"
-        assert r2d.find_repo_image()
+        revision = True
+        assert r2d.find_image(revision)
 
         instance.images.assert_called_with()
 
 
-def test_dont_find_repo_image():
+def test_dont_find_image_revision():
     images = [{"RepoTags": ["some-org/some-image-name:latest"]}]
 
     with patch("repo2docker.app.docker.APIClient") as FakeDockerClient:
@@ -62,7 +63,8 @@ def test_dont_find_repo_image():
 
         r2d = Repo2Docker()
         r2d.output_image_spec = "some-org/some-other-image-name"
-        assert not r2d.find_repo_image()
+        revision = True
+        assert not r2d.find_image(revision)
 
         instance.images.assert_called_with()
 


### PR DESCRIPTION
<!--

Our guide to getting a PR merged https://repo2docker.readthedocs.io/en/latest/contributing/contributing.html#guidelines-to-getting-a-pull-request-merged.

About to propose a big change? Read https://repo2docker.readthedocs.io/en/latest/contributing/contributing.html#process-for-making-a-contribution to maximise the chances of it getting merged quickly.

-->

WIP for #632

Command to pull in remote a repository and run an existing image instead of rebuilding because of the updated repo.
