### PR TITLE
Add `--template` to specify a Dockerfile template to use, and `--entrypoint-file` to influence Dockerfile's ENTRYPOINT

### DIFF
--- a/repo2docker/__main__.py
+++ b/repo2docker/__main__.py
@@ -193,15 +193,15 @@ def get_argparser():
     )
 
     argparser.add_argument(
-        '--template',
+        "--template",
         type=str,
-        help='Either a file to the Dockerfile template, or the template itself.',
+        help="Either a file to the Dockerfile template, or the template itself.",
     )
 
     argparser.add_argument(
-        '--entrypoint-file',
+        "--entrypoint-file",
         type=str,
-        #help=self.traits()['entrypoint_file'].help,
+        # help=self.traits()['entrypoint_file'].help,
     )
 
     return argparser
@@ -245,8 +245,7 @@ def make_r2d(argv=None):
             with open(os.path.join(args.repo, args.template)) as fp:
                 r2d.template = fp.read()
         else:
-           r2d.template = args.template
-
+            r2d.template = args.template
 
     # user wants to mount a local directory into the container for
     # editing

--- a/repo2docker/__main__.py
+++ b/repo2docker/__main__.py
@@ -192,6 +192,18 @@ def get_argparser():
         "--cache-from", action="append", default=[], help=Repo2Docker.cache_from.help
     )
 
+    argparser.add_argument(
+        '--template',
+        type=str,
+        help='Either a file to the Dockerfile template, or the template itself.',
+    )
+
+    argparser.add_argument(
+        '--entrypoint-file',
+        type=str,
+        #help=self.traits()['entrypoint_file'].help,
+    )
+
     return argparser
 
 
@@ -219,8 +231,22 @@ def make_r2d(argv=None):
     if args.appendix:
         r2d.appendix = args.appendix
 
+    if args.entrypoint_file:
+        r2d.entrypoint_file = args.entrypoint_file
+
     r2d.repo = args.repo
     r2d.ref = args.ref
+
+    if args.template:
+        if os.path.isfile(args.template):
+            with open(args.template) as fp:
+                r2d.template = fp.read()
+        elif os.path.isfile(os.path.join(args.repo, args.template)):
+            with open(os.path.join(args.repo, args.template)) as fp:
+                r2d.template = fp.read()
+        else:
+           r2d.template = args.template
+
 
     # user wants to mount a local directory into the container for
     # editing

--- a/repo2docker/app.py
+++ b/repo2docker/app.py
@@ -40,6 +40,7 @@ from .buildpacks import (
 )
 from . import contentproviders
 from .utils import ByteSpecification, chdir
+from .buildpacks.base import TEMPLATE, ENTRYPOINT_FILE
 
 
 class Repo2Docker(Application):
@@ -326,7 +327,7 @@ class Repo2Docker(Application):
     all_ports = Bool(
         False,
         help="""
-        Publish all declared ports from container whiel running.
+        Publish all declared ports from container while running.
 
         Equivalent to -P option to docker run
         """,
@@ -364,6 +365,22 @@ class Repo2Docker(Application):
         Defaults to ${HOME} if not set
         """,
         config=True,
+    )
+
+    template = Unicode(
+        TEMPLATE,
+        help="""
+        Jinja template used to render the Dockerfile.
+        """,
+        config=True
+    )
+
+    entrypoint_file = Unicode(
+        ENTRYPOINT_FILE,
+        help="""
+        Path to a file that will be used as an entry point in the Docker image.
+        """,
+        config=True
     )
 
     def fetch(self, url, ref, checkout_path):
@@ -683,6 +700,8 @@ class Repo2Docker(Application):
                     picked_buildpack = self.default_buildpack()
 
                 picked_buildpack.appendix = self.appendix
+                picked_buildpack.template = self.template
+                picked_buildpack.entrypoint_file = self.entrypoint_file
                 # Add metadata labels
                 picked_buildpack.labels["repo2docker.version"] = self.version
                 repo_label = "local" if os.path.isdir(self.repo) else self.repo

--- a/repo2docker/app.py
+++ b/repo2docker/app.py
@@ -40,7 +40,6 @@ from .buildpacks import (
 )
 from . import contentproviders
 from .utils import ByteSpecification, chdir
-from .buildpacks.base import TEMPLATE, ENTRYPOINT_FILE
 
 
 class Repo2Docker(Application):
@@ -368,19 +367,19 @@ class Repo2Docker(Application):
     )
 
     template = Unicode(
-        TEMPLATE,
+        "",
         help="""
         Jinja template used to render the Dockerfile.
         """,
-        config=True
+        config=True,
     )
 
     entrypoint_file = Unicode(
-        ENTRYPOINT_FILE,
+        "",
         help="""
         Path to a file that will be used as an entry point in the Docker image.
         """,
-        config=True
+        config=True,
     )
 
     def fetch(self, url, ref, checkout_path):
@@ -700,8 +699,10 @@ class Repo2Docker(Application):
                     picked_buildpack = self.default_buildpack()
 
                 picked_buildpack.appendix = self.appendix
-                picked_buildpack.template = self.template
-                picked_buildpack.entrypoint_file = self.entrypoint_file
+                if self.template:
+                    picked_buildpack.template = self.template
+                if self.entrypoint_file:
+                    picked_buildpack.entrypoint_file = self.entrypoint_file
                 # Add metadata labels
                 picked_buildpack.labels["repo2docker.version"] = self.version
                 repo_label = "local" if os.path.isdir(self.repo) else self.repo

--- a/repo2docker/buildpacks/base.py
+++ b/repo2docker/buildpacks/base.py
@@ -217,6 +217,8 @@ class BuildPack:
     def __init__(self):
         self.log = logging.getLogger("repo2docker")
         self.appendix = ""
+        self.entrypoint_file = ENTRYPOINT_FILE
+        self.template = TEMPLATE
         self.labels = {}
         if sys.platform.startswith("win"):
             self.log.warning(
@@ -504,7 +506,7 @@ class BuildPack:
         """
         Render BuildPack into Dockerfile
         """
-        t = jinja2.Template(TEMPLATE)
+        t = jinja2.Template(self.template)
 
         build_script_directives = []
         last_user = "root"
@@ -625,7 +627,7 @@ class BuildPack:
             dest_path, src_path = self.generate_build_context_filename(src)
             tar.add(src_path, dest_path, filter=_filter_tar)
 
-        tar.add(ENTRYPOINT_FILE, "repo2docker-entrypoint", filter=_filter_tar)
+        tar.add(self.entrypoint_file, "repo2docker-entrypoint", filter=_filter_tar)
 
         tar.add(".", "src/", filter=_filter_tar)
 


### PR DESCRIPTION
This PR disentangles `TEMPLATE` and `ENTRYPOINT_FILE` from base buildpack. Both can now be passed as runtime argument or overridden by a child class. For convenience `r2d --template` accepts either a path to a file with a template or a template as a string.