### PR TITLE
[MRG] Switch to recommending to install from master

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,13 +32,22 @@ Supported on Linux and macOS. [See documentation note about Windows support.](ht
 
 This a quick guide to installing `repo2docker`, see our documentation for [a full guide](https://repo2docker.readthedocs.io/en/latest/install.html).
 
-To install from PyPI:
+We recommend you install the latest and greatest version:
+```bash
+pip install -U https://github.com/jupyter/repo2docker/archive/master.zip
+```
+We frequently improve repo2docker and update the version of repo2docker on
+mybinder.org a few hours later. This means it is rare that this version
+doesn't work.
+
+Roughly every three months we will tag a release which you can install from PyPI:
 
 ```bash
-pip install jupyter-repo2docker
+pip install -U jupyter-repo2docker
 ```
 
-To install from source:
+To contribute to the documentation or source code you might want to
+install and run from a local checkout:
 
 ```bash
 git clone https://github.com/jupyter/repo2docker.git

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -3,7 +3,7 @@
 Installing ``repo2docker``
 ==========================
 
-repo2docker requires Python 3.5 and above on Linux and macOS. See
+repo2docker requires Python 3.5 and above on Linux or macOS. See
 :ref:`below <windows>` for more information about Windows support.
 
 Prerequisite: Docker
@@ -25,13 +25,17 @@ for more details.
 Installing with ``pip``
 -----------------------
 
-We recommend installing ``repo2docker`` with the ``pip`` tool::
+We recommend installing ``repo2docker`` the most recent code from the
+upstream repository, to do this run::
+
+    python3 -m pip install -U https://github.com/jupyter/repo2docker/archive/master.zip
+
+To install the latest release with the ``pip`` tool::
 
     python3 -m pip install jupyter-repo2docker
 
-for the latest release. To install the most recent code from the upstream repository, run::
-
-    python3 -m pip install https://github.com/jupyter/repo2docker/archive/master.zip
+Releases are made every three months and hence will not contain the latest
+and greatest features and improvements.
 
 For information on using ``repo2docker``, see :ref:`usage`.
 


### PR DESCRIPTION
We only make a release every three months but run master on mybinder.org
which means people see bugs that were long fixed when they run locally. So
we often tell people "try master".

I can't think of a concrete reason not to recommend this. WDYT?

closes #841 