### PR TITLE
[MRG] Preassemble pipenv environments when no dependency on src

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,5 +34,6 @@ test_file_text.txt
 
 \.vscode/
 venv
+docs/source/_build
 
 tests/dockerfile_diff.sh

--- a/.gitignore
+++ b/.gitignore
@@ -33,5 +33,6 @@ test_file_text.txt
 
 
 \.vscode/
+venv
 
 tests/dockerfile_diff.sh

--- a/repo2docker/buildpacks/pipfile/__init__.py
+++ b/repo2docker/buildpacks/pipfile/__init__.py
@@ -86,21 +86,18 @@ class PipfileBuildPack(CondaBuildPack):
             # can't install from subset if we're using setup.py
             return False
 
-        pipfile_lock_path = self.binder_path("Pipfile.lock")
-        with open_guess_encoding(pipfile_lock_path) as f:
-            pipfile_lock = json.load(f)
+        lockfile = self.binder_path("Pipfile.lock")
+        if os.path.exists(lockfile):
+            with open_guess_encoding(lockfile) as f:
+                pipfile_lock = json.load(f)
 
-            all_packages = []
+                all_packages = []
+                all_packages.extend(pipfile_lock.get("default", {}).values())
+                all_packages.extend(pipfile_lock.get("develop", {}).values())
 
-            if "default" in pipfile_lock:
-                all_packages.extend(pipfile_lock["default"].values())
-
-            if "develop" in pipfile_lock:
-                all_packages.extend(pipfile_lock["develop"].values())
-
-            for package in all_packages:
-                if isinstance(package, dict) and "path" in package:
-                    return False
+                for package in all_packages:
+                    if isinstance(package, dict) and "path" in package:
+                        return False
 
         return True
 

--- a/repo2docker/buildpacks/pipfile/__init__.py
+++ b/repo2docker/buildpacks/pipfile/__init__.py
@@ -87,6 +87,7 @@ class PipfileBuildPack(CondaBuildPack):
             return False
 
         lockfile = self.binder_path("Pipfile.lock")
+        pipfile = self.binder_path("Pipfile")
         if os.path.exists(lockfile):
             with open_guess_encoding(lockfile) as f:
                 pipfile_lock = json.load(f)
@@ -95,6 +96,16 @@ class PipfileBuildPack(CondaBuildPack):
                 all_packages.extend(pipfile_lock.get("default", {}).values())
                 all_packages.extend(pipfile_lock.get("develop", {}).values())
 
+                for package in all_packages:
+                    if isinstance(package, dict) and "path" in package:
+                        return False
+        elif os.path.exists(pipfile):
+            with open(pipfile) as f:
+                pipfile_info = toml.load(f)
+
+                all_packages = []
+                all_packages.extend(pipfile_info.get("packages", {}).values())
+                all_packages.extend(pipfile_info.get("dev-packages", {}).values())
                 for package in all_packages:
                     if isinstance(package, dict) and "path" in package:
                         return False

--- a/repo2docker/buildpacks/pipfile/__init__.py
+++ b/repo2docker/buildpacks/pipfile/__init__.py
@@ -82,7 +82,7 @@ class PipfileBuildPack(CondaBuildPack):
         If there are any local references, e.g. `"path": "./package.tar.gz"`,
         stage the whole repo prior to installation.
         """
-        if not os.path.exists("binder") and os.path.exists("setup.py"):
+        if not os.path.exists(self.binder_path(".")) and os.path.exists("setup.py"):
             # can't install from subset if we're using setup.py
             return False
 

--- a/tests/unit/test_pipenv_buildpack.py
+++ b/tests/unit/test_pipenv_buildpack.py
@@ -1,0 +1,87 @@
+import os
+
+import pytest
+
+from repo2docker import buildpacks
+
+
+@pytest.mark.parametrize("binder_dir", ["", ".binder", "binder"])
+def test_pipfile_with_no_local_dependency_is_preassembled(tmpdir, binder_dir):
+    tmpdir.chdir()
+    if binder_dir:
+        os.mkdir(binder_dir)
+
+    with open(os.path.join(binder_dir, "Pipfile"), "w") as f:
+        f.write(
+            """
+            [packages]
+            there = "*"
+            """
+        )
+
+    bp = buildpacks.PipfileBuildPack()
+    assert bp._should_preassemble_pipenv == True
+
+
+@pytest.mark.parametrize("binder_dir", ["", ".binder", "binder"])
+def test_pipfile_with_local_dependency_is_not_preassembled(tmpdir, binder_dir):
+    tmpdir.chdir()
+    if binder_dir:
+        os.mkdir(binder_dir)
+
+    with open(os.path.join(binder_dir, "Pipfile"), "w") as f:
+        f.write(
+            """
+            [packages]
+            there = "*"
+            dummy = {path=".", editable=true}
+            """
+        )
+
+    bp = buildpacks.PipfileBuildPack()
+    assert bp._should_preassemble_pipenv == False
+
+
+@pytest.mark.parametrize("binder_dir", ["", ".binder", "binder"])
+def test_lockfile_with_no_local_dependency_is_preassembled(tmpdir, binder_dir):
+    tmpdir.chdir()
+    if binder_dir:
+        os.mkdir(binder_dir)
+
+    with open(os.path.join(binder_dir, "Pipfile.lock"), "w") as f:
+        f.write(
+            """
+            {
+                "default": {
+                    "pypi-pkg-test": {
+                    }
+                }
+            }
+            """
+        )
+
+    bp = buildpacks.PipfileBuildPack()
+    assert bp._should_preassemble_pipenv == True
+
+
+@pytest.mark.parametrize("binder_dir", ["", ".binder", "binder"])
+def test_lockfile_with_local_dependency_is_not_preassembled(tmpdir, binder_dir):
+    tmpdir.chdir()
+    if binder_dir:
+        os.mkdir(binder_dir)
+
+    with open(os.path.join(binder_dir, "Pipfile.lock"), "w") as f:
+        f.write(
+            """
+            {
+                "default": {
+                    "pypi-pkg-test": {
+                        "path": "..."
+                    }
+                }
+            }
+            """
+        )
+
+    bp = buildpacks.PipfileBuildPack()
+    assert bp._should_preassemble_pipenv == False


### PR DESCRIPTION
As discussed in https://discourse.jupyter.org/t/repo2docker-image-caching/3292/2

We want to avoid pipenv installs when there has been no change in the lock file and the lock file has no dependency on the src directory.

Please point me in the direction of any code quality measures that are missing (I haven't written any tests but thought I'd get some feedback first)

Thanks!
<!--

Our guide to getting a PR merged https://repo2docker.readthedocs.io/en/latest/contributing/contributing.html#guidelines-to-getting-a-pull-request-merged.

About to propose a big change? Read https://repo2docker.readthedocs.io/en/latest/contributing/contributing.html#process-for-making-a-contribution to maximise the chances of it getting merged quickly.

-->
