### PR TITLE
Use COPY --chown to prevent extra chown layer

### DIFF
--- a/repo2docker/buildpacks/base.py
+++ b/repo2docker/buildpacks/base.py
@@ -150,11 +150,10 @@ RUN chown -R ${NB_USER}:${NB_USER} ${REPO_DIR}
 {{ sd }}
 {% endfor %}
 
-# Copy and chown stuff. This doubles the size of the repo, because
-# you can't actually copy as USER, only as root! Thanks, Docker!
+# We need docker 19.03 for --chown to work with variable substitution
+# https://github.com/moby/moby/issues/35018
 USER root
-COPY src/ ${REPO_DIR}
-RUN chown -R ${NB_USER}:${NB_USER} ${REPO_DIR}
+COPY --chown ${NB_USER} src/ ${REPO_DIR}
 
 # Run assemble scripts! These will actually turn the specification
 # in the repository into an image.


### PR DESCRIPTION
COPY directive always copied files into the image owned
by root. Since we wanted this to be owned by non-root users,
we needed a RUN chown command, which added a fresh layer to
the docker image for no good reason.

This fixes that, but requires docker 19.03 to work.

Ideally, we can either:

1. Pass NB_USER to the template, so we can expand that with
   jinja2 instead of as an env. This makes it work with earlier
   versions of docker
2. Dynamically determine which version of docker we are running,
   so we can conditionally use features. Me no likey

Fixes #164

<!--

Our guide to getting a PR merged https://repo2docker.readthedocs.io/en/latest/contributing/contributing.html#guidelines-to-getting-a-pull-request-merged.

About to propose a big change? Read https://repo2docker.readthedocs.io/en/latest/contributing/contributing.html#process-for-making-a-contribution to maximise the chances of it getting merged quickly.

-->
