### PR TITLE
Pull the image given in CACHE_FROM argument

### DIFF
--- a/pull_cache_list_test.py
+++ b/pull_cache_list_test.py
@@ -1,0 +1,40 @@
+import docker
+import json
+
+# TODO: print statements to be replaced with logger
+
+# Set up docker client
+client = docker.APIClient(base_url="unix://var/run/docker.sock")
+
+# List of example images we'd like to use as a cache
+cache_from = [
+    "sgibson91/binderhub-setup",
+    "sgibson91/binderhub-setup:latest",
+    "sgibson91/binderhub-setup:1.2.1",
+]
+
+
+def pull_cache_list(cache_from):
+    """Run `docker pull` for the images in the cache_from list. These images
+    will then be available locally for the build phase.
+
+    Arguments:
+        cache_from {list} -- List of the desired images to use as a cache
+    """
+    for image in cache_from:
+        # Check if a specific image tag has been provided by looking for ':' in
+        # the image name. If no tag has been provided, default to 'latest'.
+        if ":" in image:
+            image_name, tag = image.split(":")
+        else:
+            print("No tag present. Using 'latest'.")
+            image_name = image
+            tag = "latest"
+
+        # Pull the image from Docker Hub and stream the progress to logs
+        for line in client.pull(image_name, tag=tag, stream=True, decode=True):
+            print(json.dumps(line, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    pull_cache_list(cache_from)


### PR DESCRIPTION
### Summary

Write a function that takes in a list of docker images that are
desired cache sources for the build phase. Check each image name
for a provided tag, if not found then default to 'latest'. Pull
each image from Docker Hub, they then will be available locally
to be used as a cache during the build phase.

This was the behaviour I expected to see when using the CACHE_FROM flag, but it appears that this is not the case. Issue #130 

I have written a function that consumes the list of images, checks for tags and then pull them. I'm not sure where to put this within the repo2docker codebase though, so any guidance on that would be super appreciated ✨

It may also be useful to combine with the `find_image` function so we don't pull what we already have? https://github.com/jupyter/repo2docker/blob/bbc3ee02c0755b15ea456f9ae18dd76b904568e7/repo2docker/app.py#L613-L625

### Outstanding TODOs

- [ ] Move the code snippet to an appropriate place with the repo2docker codebase
- [ ] Swap print statements for the custom logger
- [ ] We may also want to do some handling of the pull output, like in `push_image`

https://github.com/jupyter/repo2docker/blob/bbc3ee02c0755b15ea456f9ae18dd76b904568e7/repo2docker/app.py#L458-L499