### PR TITLE
Install rmarkdown library

### DIFF
--- a/repo2docker/buildpacks/r.py
+++ b/repo2docker/buildpacks/r.py
@@ -314,6 +314,15 @@ class RBuildPack(PythonBuildPack):
                 ),
             ),
             (
+                "${NB_USER}",
+                # Install rmarkdown library (for background, see https://github.com/jupyter/repo2docker/issues/799, as well as Section 3.2 at https://docs.rstudio.com/shiny-server/)
+                r"""
+                R --quiet -e "install.packages('rmarkdown', repos='{}', method='libcurl')"
+                """.format(
+                    mran_url
+                ),
+            ),
+            (
                 "root",
                 # We set the default CRAN repo to the MRAN one at given date
                 # We set download method to be curl so we get HTTPS support


### PR DESCRIPTION
Installing (at least trying to install) `rmarkdown` library (for background, see https://github.com/jupyter/repo2docker/issues/799, as well as Section 3.2 at https://docs.rstudio.com/shiny-server/)

Hi all (esp. @choldgraf),

I've looked back into #799. To my joy, it turns out that Shiny Server already implemented a hierarchical logic whereby R Markdown scripts are sought after pure Shiny ones, as [quoted below from RStudio](https://docs.rstudio.com/shiny-server/).

> **3.2 R Markdown**
>
> In addition to serving traditional Shiny applications out of a directory (a server.R file and an associated UI), Shiny Server now supports interactive R Markdown documents. To take advantage of this capability, you will need to make sure that R Markdown is installed and available for all users. You can do so by running the following command:
> 
> `sudo su - -c "R -e \"install.packages('rmarkdown')\""`
> 
> If a hosted directory does not include a server.R file, Shiny Server will look to see if it contains any .Rmd files. If so, Shiny Server will host that directory in "R Markdown" mode using `rmarkdown::run`.
> 
> Particular Rmd files can be accessed by referencing their full path including the filename, e.g., http://myserver.org/mydocs/hello.Rmd. If a request is made to a directory rather than to a particular Rmd file, Shiny Server will attempt to serve the file index.Rmd. If that file does not exist, the user will get an error alerting them that the file is not available.

So, I've tried to install `rmarkdown`. I would be grateful for a review of this. If this is merged, I would then follow up whether the new feature works, by looking at the document mentioned in #799.

Thank you very much


<!--

Our guide to getting a PR merged https://repo2docker.readthedocs.io/en/latest/contributing/contributing.html#guidelines-to-getting-a-pull-request-merged.

About to propose a big change? Read https://repo2docker.readthedocs.io/en/latest/contributing/contributing.html#process-for-making-a-contribution to maximise the chances of it getting merged quickly.

-->
