### PR TITLE
Set read and execute (a+rx) permission for the repo2docker-entrypoint file

### DIFF
--- a/repo2docker/buildpacks/base.py
+++ b/repo2docker/buildpacks/base.py
@@ -188,6 +188,10 @@ ENV R2D_ENTRYPOINT "{{ start_script }}"
 
 # Add entrypoint
 COPY /repo2docker-entrypoint /usr/local/bin/repo2docker-entrypoint
+USER root
+RUN chmod a+rx /usr/local/bin/repo2docker-entrypoint
+RUN chown ${NB_USER}:${NB_USER} /usr/local/bin/repo2docker-entrypoint
+USER ${NB_USER}
 ENTRYPOINT ["/usr/local/bin/repo2docker-entrypoint"]
 
 # Specify the default command to run

--- a/repo2docker/buildpacks/base.py
+++ b/repo2docker/buildpacks/base.py
@@ -189,8 +189,8 @@ ENV R2D_ENTRYPOINT "{{ start_script }}"
 # Add entrypoint
 COPY /repo2docker-entrypoint /usr/local/bin/repo2docker-entrypoint
 USER root
-RUN chmod a+rx /usr/local/bin/repo2docker-entrypoint
-RUN chown ${NB_USER}:${NB_USER} /usr/local/bin/repo2docker-entrypoint
+RUN chmod a+rx /usr/local/bin/repo2docker-entrypoint \
+ && chown ${NB_USER}:${NB_USER} /usr/local/bin/repo2docker-entrypoint
 USER ${NB_USER}
 ENTRYPOINT ["/usr/local/bin/repo2docker-entrypoint"]
 


### PR DESCRIPTION
Fix for error after building image: /bin/bash: /usr/local/bin/repo2docker-entrypoint: Permission denied

Fixes #775 