### PR TITLE
little improvement for testing binder_dir

### DIFF
--- a/tests/unit/test_binder_dir.py
+++ b/tests/unit/test_binder_dir.py
@@ -5,20 +5,15 @@ import pytest
 from repo2docker import buildpacks
 
 
-@pytest.mark.parametrize("binder_dir", [".binder", "binder"])
-def test_binder_dir_property(tmpdir, binder_dir):
+@pytest.mark.parametrize("binder_dir", ["binder", ".binder", ""])
+def test_binder_dir(tmpdir, binder_dir):
     tmpdir.chdir()
-    os.mkdir(binder_dir)
+    if binder_dir:
+        os.mkdir(binder_dir)
 
     bp = buildpacks.BuildPack()
-    assert binder_dir in bp.binder_dir
+    assert binder_dir == bp.binder_dir
     assert bp.binder_path("foo.yaml") == os.path.join(binder_dir, "foo.yaml")
-
-
-def test_root_binder_dir(tmpdir):
-    tmpdir.chdir()
-    bp = buildpacks.BuildPack()
-    assert bp.binder_dir == ""
 
 
 def test_exclusive_binder_dir(tmpdir):


### PR DESCRIPTION
- merges 2 similar test cases
- replaces `in` with `==`, because `"binder" in ".binder"` returns True but it should return false in this test case
