### PR TITLE
[MRG] Handle requirements.txt with `--pre` lines

### DIFF
--- a/repo2docker/utils.py
+++ b/repo2docker/utils.py
@@ -469,6 +469,10 @@ def is_local_pip_requirement(line):
     if line.startswith(("--requirement", "--constraint")):
         # as above but flags are spelt out
         return True
+    # the `--pre` flag is a global flag and should appear on a line by itself
+    # we just care that this isn't a "local pip requirement"
+    if line.startswith("--pre"):
+        return False
     # strip off things like `--editable=`. Long form arguments require a =
     if line.startswith("--"):
         line = line.split("=", 1)[1]

--- a/repo2docker/utils.py
+++ b/repo2docker/utils.py
@@ -473,14 +473,29 @@ def is_local_pip_requirement(line):
     # we just care that this isn't a "local pip requirement"
     if line.startswith("--pre"):
         return False
+
     # strip off things like `--editable=`. Long form arguments require a =
     if line.startswith("--"):
-        line = line.split("=", 1)[1]
+        # if splitting doesn't work it is probably because the line contains
+        # a syntax error or our "parser" is too simplistic so we return True
+        # just in case
+        try:
+            line = line.split("=", 1)[1]
+        except IndexError:
+            return True
+
     # strip off short form arguments like `-e`. Short form arguments can be
     # followed by a space `-e foo` or use `-e=foo`. The latter is not handled
     # here. We can deal with it when we see someone using it.
     if line.startswith("-"):
-        line = line.split(None, 1)[1]
+        # if splitting doesn't work it is probably because the line contains
+        # a syntax error or our "parser" is too simplistic so we return True
+        # just in case
+        try:
+            line = line.split(None, 1)[1]
+        except IndexError:
+            return True
+
     if "file://" in line:
         # file references break isolation
         return True

--- a/repo2docker/utils.py
+++ b/repo2docker/utils.py
@@ -463,48 +463,48 @@ def is_local_pip_requirement(line):
     line = line.split("#", 1)[0].strip()
     if not line:
         return False
+
     if line.startswith(("-r", "-c")):
         # local -r or -c references break isolation
         return True
+
     if line.startswith(("--requirement", "--constraint")):
         # as above but flags are spelt out
         return True
+
     # the `--pre` flag is a global flag and should appear on a line by itself
     # we just care that this isn't a "local pip requirement"
     if line.startswith("--pre"):
         return False
 
     # strip off things like `--editable=`. Long form arguments require a =
-    if line.startswith("--"):
-        # if splitting doesn't work it is probably because the line contains
-        # a syntax error or our "parser" is too simplistic so we return True
-        # just in case
-        try:
-            line = line.split("=", 1)[1]
-        except IndexError:
-            return True
+    # if there is no = it is probably because the line contains
+    # a syntax error or our "parser" is too simplistic
+    if line.startswith("--") and "=" in line:
+        _, line = line.split("=", 1)
 
     # strip off short form arguments like `-e`. Short form arguments can be
     # followed by a space `-e foo` or use `-e=foo`. The latter is not handled
     # here. We can deal with it when we see someone using it.
     if line.startswith("-"):
-        # if splitting doesn't work it is probably because the line contains
-        # a syntax error or our "parser" is too simplistic so we return True
-        # just in case
-        try:
-            line = line.split(None, 1)[1]
-        except IndexError:
-            return True
+        _, *rest = line.split(None, 1)
+        if not rest:
+            # no argument after `--flag`, skip line
+            return False
+        line = rest[0]
 
     if "file://" in line:
         # file references break isolation
         return True
+
     if "://" in line:
         # handle git://../local/file
         path = line.split("://", 1)[1]
     else:
         path = line
+
     if path.startswith("."):
         # references a local file
         return True
+
     return False

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -147,7 +147,13 @@ def test_open_guess_encoding():
         ("numpy", False),
         ("# -e .", False),
         ("--pre", False),
+        # pip ignores the package name and treats this like `--pre` on a line
+        # by itself
         ("--pre pandas", False),
+        # These are invalid lines as far as pip is concerned, check that our
+        # code is robust and continues running
+        ("--unrecognized", True),
+        ("-e", True),
     ],
 )
 def test_local_pip_requirement(req, is_local):

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -146,6 +146,8 @@ def test_open_guess_encoding():
         ("git+https://github.com/jupyterhub/repo2docker", False),
         ("numpy", False),
         ("# -e .", False),
+        ("--pre", False),
+        ("--pre pandas", False),
     ],
 )
 def test_local_pip_requirement(req, is_local):

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -152,8 +152,8 @@ def test_open_guess_encoding():
         ("--pre pandas", False),
         # These are invalid lines as far as pip is concerned, check that our
         # code is robust and continues running
-        ("--unrecognized", True),
-        ("-e", True),
+        ("--unrecognized", False),
+        ("-e", False),
     ],
 )
 def test_local_pip_requirement(req, is_local):


### PR DESCRIPTION
This is a global flag which our inspection of `requirements.txt` files
should ignore as it doesn't imply a local reference.