### PR TITLE
Add `www-frame-origin=same` to /etc/rstudio/rserver.conf

### DIFF
--- a/repo2docker/buildpacks/conda/__init__.py
+++ b/repo2docker/buildpacks/conda/__init__.py
@@ -309,7 +309,8 @@ class CondaBuildPack(BaseImage):
                     r"""
                     echo auth-none=1 >> /etc/rstudio/rserver.conf && \
                     echo auth-minimum-user-id=0 >> /etc/rstudio/rserver.conf && \
-                    echo "rsession-which-r={0}/bin/R" >> /etc/rstudio/rserver.conf
+                    echo "rsession-which-r={0}/bin/R" >> /etc/rstudio/rserver.conf && \
+                    echo www-frame-origin=same >> /etc/rstudio/rserver.conf
                     """.format(
                         env_prefix
                     ),


### PR DESCRIPTION
Currently, we can't open RStudio from the JupyterLab launcher because of the `x-frame-options: DENY` header that RStudio sends by default:
![image](https://user-images.githubusercontent.com/5837628/90254834-3c35ad00-ddf8-11ea-9a49-ec9849e2140a.png)
Opening `/rstudio` in its own tab works.

This PR adds the `www-frame-origin=same` config to `/etc/rstudio/rserver.conf`, [setting the header](https://docs.rstudio.com/ide/server-pro/access-and-security.html#frame-origin) to `X-Frame-Options: SAMEORIGIN`, allowing RStudio to be opened in the JupyterLab interface.
![image](https://user-images.githubusercontent.com/5837628/90255899-ca5e6300-ddf9-11ea-946c-41a07e4ebc88.png)

I'm making this PR since the config file is only writable as root and can't be fixed in `postBuild`. Let me know if I need to do anything further.