### PR TITLE
Add Julia 1.5.1 support

### DIFF
--- a/repo2docker/buildpacks/julia/julia_project.py
+++ b/repo2docker/buildpacks/julia/julia_project.py
@@ -30,6 +30,7 @@ class JuliaProjectTomlBuildPack(PythonBuildPack):
         "1.4.1",
         "1.4.2",
         "1.5.0",
+        "1.5.1",
     ]
 
     @property


### PR DESCRIPTION
<!--

Our guide to getting a PR merged https://repo2docker.readthedocs.io/en/latest/contributing/contributing.html#guidelines-to-getting-a-pull-request-merged.

About to propose a big change? Read https://repo2docker.readthedocs.io/en/latest/contributing/contributing.html#process-for-making-a-contribution to maximise the chances of it getting merged quickly.

-->

Julia 1.5.1 was released last week.