### PR TITLE
[MRG] Bump Python requirement to 3.6 from 3.5

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,7 +78,7 @@ jobs:
           - unit
           - venv
         include:
-          - python_version: "3.5"
+          - python_version: "3.6"
             repo_type: venv
 
     steps:

--- a/README.md
+++ b/README.md
@@ -16,15 +16,13 @@ For support questions please search or post to https://discourse.jupyter.org/c/b
 See the [contributing guide](CONTRIBUTING.md) for information on contributing to
 repo2docker.
 
-See [our roadmap](https://repo2docker.readthedocs.io/en/latest/contributing/roadmap.html)
-to learn about where the project is heading.
 
 ## Using repo2docker
 ### Prerequisites
 
 1. Docker to build & run the repositories. The [community edition](https://store.docker.com/search?type=edition&offering=community)
    is recommended.
-2. Python 3.5+.
+2. Python 3.6+.
 
 Supported on Linux and macOS. [See documentation note about Windows support.](http://repo2docker.readthedocs.io/en/latest/install.html#note-about-windows-support)
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -3,7 +3,7 @@
 Installing ``repo2docker``
 ==========================
 
-repo2docker requires Python 3.5 and above on Linux and macOS. See
+repo2docker requires Python 3.6 or above on Linux and macOS. See
 :ref:`below <windows>` for more information about Windows support.
 
 Prerequisite: Docker

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
         "toml",
         "semver",
     ],
-    python_requires=">=3.5",
+    python_requires=">=3.6",
     author="Project Jupyter Contributors",
     author_email="jupyter@googlegroups.com",
     url="https://repo2docker.readthedocs.io/en/latest/",


### PR DESCRIPTION
This increases the lowest version of Python required to run repo2docker itself.

From https://www.python.org/dev/peps/pep-0478/ it looks like there will be no more new relases for 3.5 which is the first step towards it becoming unsupported.

Does someone remember why we should continue to support 3.5 for running repo2docker itself?

For #950 to land we need to have at least Python 3.6.