### PR TITLE
[MRG] Crosslink 'Configuring your repository' with usage

### DIFF
--- a/docs/source/configuration/index.rst
+++ b/docs/source/configuration/index.rst
@@ -5,6 +5,8 @@ Configuring your repository
 Information about configuring your repository to work with repo2docker,
 and controlling elements of the built environment using configuration files.
 
+For information on where to put your configuration files see :ref:`usage-config-file-location`.
+
 .. toctree::
    :maxdepth: 2
    :caption: Complete list of configuration files

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -79,6 +79,8 @@ specify the ``branch-name`` or ``commit-hash``. For example::
    commit-hash will result in the latest commit of the repository being built.
 
 
+.. _usage-config-file-location:
+
 Where to put configuration files
 ================================
 


### PR DESCRIPTION
[`Configuring your repository`](https://repo2docker.readthedocs.io/en/latest/configuration/index.html) is one of the main headings, so I think it should mention where configuration files should go.
