### PR TITLE
MRG: Add workflow to build Docker image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,24 @@
+name: Docker build
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  docker:
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      # https://github.com/docker/build-push-action
+      - name: Build Docker image
+        uses: docker/build-push-action@v1
+        with:
+          repository: jupyter/repo2docker
+          push: false
+
+      - name: Run repo2docker Docker image
+        run: docker run jupyter/repo2docker repo2docker --version

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -18,7 +18,8 @@ jobs:
         uses: docker/build-push-action@v1
         with:
           repository: jupyter/repo2docker
+          tags: pr
           push: false
 
       - name: Run repo2docker Docker image
-        run: docker run jupyter/repo2docker repo2docker --version
+        run: docker run jupyter/repo2docker:pr repo2docker --version


### PR DESCRIPTION
The Docker Cloud CI logs are currently inaccessible to the public
https://github.com/jupyterhub/repo2docker/pull/950#issuecomment-688731046

Regardless it's probably easier to have all CI workflows in one place.