### PR TITLE
Bump Black version to 20.8b1 and use --target-version=py36

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/ambv/black
-  rev: 19.10b0
+  rev: 20.8b1
   hooks:
   - id: black
-    args: [--target-version=py35]
+    args: [--target-version=py36]

--- a/repo2docker/buildpacks/conda/__init__.py
+++ b/repo2docker/buildpacks/conda/__init__.py
@@ -266,8 +266,7 @@ class CondaBuildPack(BaseImage):
         return assemble_files
 
     def get_env_scripts(self):
-        """Return series of build-steps specific to this source repository.
-        """
+        """Return series of build-steps specific to this source repository."""
         scripts = []
         environment_yml = self.binder_path("environment.yml")
         env_prefix = "${KERNEL_PYTHON_PREFIX}" if self.py2 else "${NB_PYTHON_PREFIX}"
@@ -340,6 +339,5 @@ class CondaBuildPack(BaseImage):
         return scripts
 
     def detect(self):
-        """Check if current repo should be built with the Conda BuildPack.
-        """
+        """Check if current repo should be built with the Conda BuildPack."""
         return os.path.exists(self.binder_path("environment.yml")) and super().detect()

--- a/repo2docker/buildpacks/julia/julia_project.py
+++ b/repo2docker/buildpacks/julia/julia_project.py
@@ -86,9 +86,9 @@ class JuliaProjectTomlBuildPack(PythonBuildPack):
     def get_path(self):
         """Adds path to Julia binaries to user's PATH.
 
-         Returns:
-             an ordered list of path strings. The path to the Julia
-             executable is added to the list.
+        Returns:
+            an ordered list of path strings. The path to the Julia
+            executable is added to the list.
 
         """
         return super().get_path() + ["${JULIA_PATH}/bin"]

--- a/repo2docker/buildpacks/julia/julia_require.py
+++ b/repo2docker/buildpacks/julia/julia_require.py
@@ -88,9 +88,9 @@ class JuliaRequireBuildPack(PythonBuildPack):
     def get_path(self):
         """Adds path to Julia binaries to user's PATH.
 
-         Returns:
-             an ordered list of path strings. The path to the Julia
-             executable is added to the list.
+        Returns:
+            an ordered list of path strings. The path to the Julia
+            executable is added to the list.
 
         """
         return super().get_path() + ["${JULIA_HOME}"]

--- a/repo2docker/buildpacks/nix/__init__.py
+++ b/repo2docker/buildpacks/nix/__init__.py
@@ -8,8 +8,7 @@ class NixBuildPack(BaseImage):
     """A nix Package Manager BuildPack"""
 
     def get_path(self):
-        """Return paths to be added to PATH environemnt variable
-        """
+        """Return paths to be added to PATH environemnt variable"""
         return super().get_path() + ["/home/${NB_USER}/.nix-profile/bin"]
 
     def get_env(self):
@@ -47,16 +46,14 @@ class NixBuildPack(BaseImage):
         ]
 
     def get_build_script_files(self):
-        """Dict of files to be copied to the container image for use in building
-        """
+        """Dict of files to be copied to the container image for use in building"""
         return {
             "nix/install-nix.bash": "/home/${NB_USER}/.local/bin/install-nix.bash",
             "nix/nix-shell-wrapper": "/usr/local/bin/nix-shell-wrapper",
         }
 
     def get_assemble_scripts(self):
-        """Return series of build-steps specific to this source repository.
-        """
+        """Return series of build-steps specific to this source repository."""
         return super().get_assemble_scripts() + [
             (
                 "${NB_USER}",

--- a/repo2docker/buildpacks/pipfile/__init__.py
+++ b/repo2docker/buildpacks/pipfile/__init__.py
@@ -93,8 +93,7 @@ class PipfileBuildPack(CondaBuildPack):
         return scripts
 
     def get_assemble_scripts(self):
-        """Return series of build-steps specific to this repository.
-        """
+        """Return series of build-steps specific to this repository."""
         # If we have either Pipfile.lock, Pipfile, or runtime.txt declare the
         # use of Python 2, Python 2.7 will be made available in the *kernel*
         # environment. The notebook servers environment on the other hand
@@ -168,8 +167,7 @@ class PipfileBuildPack(CondaBuildPack):
         return assemble_scripts
 
     def detect(self):
-        """Check if current repo should be built with the Pipfile buildpack.
-        """
+        """Check if current repo should be built with the Pipfile buildpack."""
         # first make sure python is not explicitly unwanted
         runtime_txt = self.binder_path("runtime.txt")
         if os.path.exists(runtime_txt):

--- a/repo2docker/buildpacks/python/__init__.py
+++ b/repo2docker/buildpacks/python/__init__.py
@@ -132,8 +132,7 @@ class PythonBuildPack(CondaBuildPack):
         return assemble_scripts
 
     def detect(self):
-        """Check if current repo should be built with the Python buildpack.
-        """
+        """Check if current repo should be built with the Python buildpack."""
         requirements_txt = self.binder_path("requirements.txt")
         runtime_txt = self.binder_path("runtime.txt")
         setup_py = "setup.py"

--- a/repo2docker/contentproviders/dataverse.py
+++ b/repo2docker/contentproviders/dataverse.py
@@ -12,7 +12,7 @@ from ..utils import copytree, deep_get
 class Dataverse(DoiProvider):
     """
     Provide contents of a Dataverse dataset.
-    
+
     This class loads a a list of existing Dataverse installations from the internal
     file dataverse.json. This file is manually updated with the following command:
 

--- a/repo2docker/contentproviders/figshare.py
+++ b/repo2docker/contentproviders/figshare.py
@@ -15,7 +15,7 @@ from ..utils import copytree, deep_get
 
 class Figshare(DoiProvider):
     """Provide contents of a Figshare article.
-    
+
     See https://docs.figshare.com/#public_article for API docs.
 
     Examples:


### PR DESCRIPTION
The required Python version is now 3.6 (https://github.com/jupyterhub/repo2docker/pull/951).

`--target-version=py36` will allow in particular f-strings.
