### PR TITLE
Let `CMD <cmd>` in the Dockerfile template be configurable

### DIFF
--- a/repo2docker/buildpacks/base.py
+++ b/repo2docker/buildpacks/base.py
@@ -191,7 +191,7 @@ COPY /repo2docker-entrypoint /usr/local/bin/repo2docker-entrypoint
 ENTRYPOINT ["/usr/local/bin/repo2docker-entrypoint"]
 
 # Specify the default command to run
-CMD ["jupyter", "notebook", "--ip", "0.0.0.0"]
+CMD [{% for c in command -%} "{{ c }}"{{ "," if not loop.last }} {% endfor -%}]
 
 {% if appendix -%}
 # Appendix:
@@ -482,6 +482,14 @@ class BuildPack:
         """
         return None
 
+    def get_command(self):
+        """
+        The default command to be run by docker.
+
+        This should return a list of strings to be used as Dockerfile `CMD`.
+        """
+        return ["jupyter", "notebook", "--ip", "0.0.0.0"]
+
     @property
     def binder_dir(self):
         has_binder = os.path.isdir("binder")
@@ -568,6 +576,7 @@ class BuildPack:
             base_packages=sorted(self.get_base_packages()),
             post_build_scripts=self.get_post_build_scripts(),
             start_script=self.get_start_script(),
+            command=self.get_command(),
             appendix=self.appendix,
         )
 

--- a/repo2docker/buildpacks/base.py
+++ b/repo2docker/buildpacks/base.py
@@ -191,7 +191,7 @@ COPY /repo2docker-entrypoint /usr/local/bin/repo2docker-entrypoint
 ENTRYPOINT ["/usr/local/bin/repo2docker-entrypoint"]
 
 # Specify the default command to run
-CMD [{% for c in command -%} "{{ c }}"{{ "," if not loop.last }} {% endfor -%}]
+CMD [{% for c in command -%} "{{ c }}"{{ ", " if not loop.last }}{% endfor -%}]
 
 {% if appendix -%}
 # Appendix:

--- a/repo2docker/buildpacks/base.py
+++ b/repo2docker/buildpacks/base.py
@@ -571,7 +571,9 @@ class BuildPack:
             cmd = str(cmd).replace("'", '"')
         if not isinstance(cmd, str):
             raise ValueError(
-                'Method "get_command" of buildpack "%s" must return a string, a list or a tuple.' % self.__class__.__name__)
+                'Method "get_command" of buildpack "%s" must return a string, a list or a tuple.'
+                % self.__class__.__name__
+            )
 
         return t.render(
             packages=sorted(self.get_packages()),

--- a/repo2docker/buildpacks/base.py
+++ b/repo2docker/buildpacks/base.py
@@ -10,7 +10,6 @@ import sys
 import hashlib
 import escapism
 import xml.etree.ElementTree as ET
-from collections.abc import Iterable
 
 from traitlets import Dict
 


### PR DESCRIPTION
A configurable CMD might not be something this project wants but there are many use-cases for this, like starting the notebook in a different way or even using Repo2Docker as a library to build non-jupyter Docker images. It would be nice to have this feature.

By the way, this change is completely **backward-compatible** and **does not affect** anyone who does not want to change the CMD.
