### PR TITLE
Mamba number three

### DIFF
--- a/repo2docker/buildpacks/conda/__init__.py
+++ b/repo2docker/buildpacks/conda/__init__.py
@@ -79,7 +79,7 @@ class CondaBuildPack(BaseImage):
             (
                 "root",
                 r"""
-                bash /tmp/install-miniforge.bash && \
+                bash -c 'time /tmp/install-miniforge.bash' && \
                 rm /tmp/install-miniforge.bash /tmp/environment.yml
                 """,
             )
@@ -275,9 +275,10 @@ class CondaBuildPack(BaseImage):
                 (
                     "${NB_USER}",
                     r"""
-                conda env update -p {0} -f "{1}" && \
-                conda clean --all -f -y && \
-                conda list -p {0}
+                bash -c 'time mamba env update -p {0} -f "{1}" && \
+                time mamba clean --all -f -y && \
+                mamba list -p {0} \
+                '
                 """.format(
                         env_prefix, environment_yml
                     ),
@@ -293,9 +294,9 @@ class CondaBuildPack(BaseImage):
                 (
                     "${NB_USER}",
                     r"""
-                conda install -p {0} r-base{1} r-irkernel={2} r-devtools && \
-                conda clean --all -f -y && \
-                conda list -p {0}
+                time mamba install -p {0} r-base{1} r-irkernel={2} r-devtools && \
+                time mamba clean --all -f -y && \
+                mamba list -p {0}
                 """.format(
                         env_prefix, r_pin, IRKERNEL_VERSION
                     ),

--- a/repo2docker/buildpacks/conda/__init__.py
+++ b/repo2docker/buildpacks/conda/__init__.py
@@ -294,7 +294,7 @@ class CondaBuildPack(BaseImage):
                 (
                     "${NB_USER}",
                     r"""
-                mamba install -p {0} r-base{1} r-irkernel={2} r-devtools && \
+                mamba install -p {0} r-base{1} r-irkernel={2} r-devtools -y && \
                 mamba clean --all -f -y && \
                 mamba list -p {0}
                 """.format(

--- a/repo2docker/buildpacks/conda/__init__.py
+++ b/repo2docker/buildpacks/conda/__init__.py
@@ -294,8 +294,8 @@ class CondaBuildPack(BaseImage):
                 (
                     "${NB_USER}",
                     r"""
-                time mamba install -p {0} r-base{1} r-irkernel={2} r-devtools && \
-                time mamba clean --all -f -y && \
+                mamba install -p {0} r-base{1} r-irkernel={2} r-devtools && \
+                mamba clean --all -f -y && \
                 mamba list -p {0}
                 """.format(
                         env_prefix, r_pin, IRKERNEL_VERSION

--- a/repo2docker/buildpacks/conda/install-miniforge.bash
+++ b/repo2docker/buildpacks/conda/install-miniforge.bash
@@ -1,9 +1,12 @@
 #!/bin/bash
-# This downloads and installs a pinned version of miniconda
+# This downloads and installs a pinned version of miniforge
+# and sets up the base environment
 set -ex
+
 
 cd $(dirname $0)
 MINIFORGE_VERSION=4.8.2-1
+MAMBA_VERSION=0.3.8
 # SHA256 for installers can be obtained from https://github.com/conda-forge/miniforge/releases
 SHA256SUM="4f897e503bd0edfb277524ca5b6a5b14ad818b3198c2f07a36858b7d88c928db"
 
@@ -14,7 +17,7 @@ INSTALLER_PATH=/tmp/miniforge-installer.sh
 # since this is run as root
 unset HOME
 
-wget --quiet $URL -O ${INSTALLER_PATH}
+time wget --quiet $URL -O ${INSTALLER_PATH}
 chmod +x ${INSTALLER_PATH}
 
 # check sha256 checksum
@@ -23,7 +26,7 @@ if ! echo "${SHA256SUM}  ${INSTALLER_PATH}" | sha256sum  --quiet -c -; then
     exit 1
 fi
 
-bash ${INSTALLER_PATH} -b -p ${CONDA_DIR}
+time bash ${INSTALLER_PATH} -b -p ${CONDA_DIR}
 export PATH="${CONDA_DIR}/bin:$PATH"
 
 # Preserve behavior of miniconda - packages come from conda-forge + defaults
@@ -39,20 +42,25 @@ echo 'update_dependencies: false' >> ${CONDA_DIR}/.condarc
 # avoid future changes to default channel_priority behavior
 conda config --system --set channel_priority "flexible"
 
+# do all installation with mamba
+time conda install -y mamba==${MAMBA_VERSION}
+# switch back to conda
+# ln -s $CONDA_DIR/bin/conda $CONDA_DIR/bin/mamba
+
 echo "installing notebook env:"
 cat /tmp/environment.yml
-conda env create -p ${NB_PYTHON_PREFIX} -f /tmp/environment.yml
+time mamba env create -p ${NB_PYTHON_PREFIX} -f /tmp/environment.yml
 
 # Install jupyter-offline-notebook to allow users to download notebooks
 # after the server connection has been lost
 # This will install and enable the extension for jupyter notebook
-${NB_PYTHON_PREFIX}/bin/python -m pip install jupyter-offlinenotebook==0.1.0
+time ${NB_PYTHON_PREFIX}/bin/python -m pip install jupyter-offlinenotebook==0.1.0
 # and this installs it for lab. Keep going if the lab version is incompatible
 # with the extension.
 # Don't minimize build as it may fail, possibly due to excessive resource usage
 # https://discourse.jupyter.org/t/tip-binder-jupyterlab-extension/6022
 # https://discourse.jupyter.org/t/jupyter-lab-build-hangs-and-then-fails-at-webpack-config-webpack-prod-minimize-config-js/6017/3
-${NB_PYTHON_PREFIX}/bin/jupyter labextension install --no-build jupyter-offlinenotebook && \
+time ${NB_PYTHON_PREFIX}/bin/jupyter labextension install --no-build jupyter-offlinenotebook && \
 $NB_PYTHON_PREFIX/bin/jupyter lab build --minimize=False || \
 true
 
@@ -67,14 +75,14 @@ if [[ -f /tmp/kernel-environment.yml ]]; then
     echo "installing kernel env:"
     cat /tmp/kernel-environment.yml
 
-    conda env create -p ${KERNEL_PYTHON_PREFIX} -f /tmp/kernel-environment.yml
+    time mamba env create -p ${KERNEL_PYTHON_PREFIX} -f /tmp/kernel-environment.yml
     ${KERNEL_PYTHON_PREFIX}/bin/ipython kernel install --prefix "${NB_PYTHON_PREFIX}"
     echo '' > ${KERNEL_PYTHON_PREFIX}/conda-meta/history
-    conda list -p ${KERNEL_PYTHON_PREFIX}
+    mamba list -p ${KERNEL_PYTHON_PREFIX}
 fi
 
 # Clean things out!
-conda clean --all -f -y
+time mamba clean --all -f -y
 
 # Remove the big installer so we don't increase docker image size too much
 rm ${INSTALLER_PATH}
@@ -84,5 +92,5 @@ rm -rf /root/.cache
 
 chown -R $NB_USER:$NB_USER ${CONDA_DIR}
 
-conda list -n root
-conda list -p ${NB_PYTHON_PREFIX}
+mamba list -n root
+mamba list -p ${NB_PYTHON_PREFIX}

--- a/repo2docker/buildpacks/conda/install-miniforge.bash
+++ b/repo2docker/buildpacks/conda/install-miniforge.bash
@@ -6,7 +6,7 @@ set -ex
 
 cd $(dirname $0)
 MINIFORGE_VERSION=4.8.2-1
-MAMBA_VERSION=0.3.8
+MAMBA_VERSION=0.5.1
 # SHA256 for installers can be obtained from https://github.com/conda-forge/miniforge/releases
 SHA256SUM="4f897e503bd0edfb277524ca5b6a5b14ad818b3198c2f07a36858b7d88c928db"
 

--- a/repo2docker/buildpacks/conda/install-miniforge.bash
+++ b/repo2docker/buildpacks/conda/install-miniforge.bash
@@ -61,7 +61,7 @@ time ${NB_PYTHON_PREFIX}/bin/python -m pip install jupyter-offlinenotebook==0.1.
 # https://discourse.jupyter.org/t/tip-binder-jupyterlab-extension/6022
 # https://discourse.jupyter.org/t/jupyter-lab-build-hangs-and-then-fails-at-webpack-config-webpack-prod-minimize-config-js/6017/3
 time ${NB_PYTHON_PREFIX}/bin/jupyter labextension install --no-build jupyter-offlinenotebook && \
-$NB_PYTHON_PREFIX/bin/jupyter lab build --minimize=False || \
+time $NB_PYTHON_PREFIX/bin/jupyter lab build --minimize=False || \
 true
 
 # empty conda history file,


### PR DESCRIPTION
cc @minrk - all tests are passing!

This is an update on #919 (I could not push to your branch anymore).

 - The failure in #919 was due to a missing `-y` in `mamba install`, which caused the logs to overflow with repeted `Confirm changes: [Y/n]`
 - I don't know why the `-y` was not required for the `conda install` command.

I also updated mamba to the latest