### PR TITLE
MRG: set TIMEFORMAT for timed bash conda commands

### DIFF
--- a/repo2docker/buildpacks/conda/__init__.py
+++ b/repo2docker/buildpacks/conda/__init__.py
@@ -79,6 +79,7 @@ class CondaBuildPack(BaseImage):
             (
                 "root",
                 r"""
+                TIMEFORMAT='time: %3R' \
                 bash -c 'time /tmp/install-miniforge.bash' && \
                 rm /tmp/install-miniforge.bash /tmp/environment.yml
                 """,
@@ -275,6 +276,7 @@ class CondaBuildPack(BaseImage):
                 (
                     "${NB_USER}",
                     r"""
+                TIMEFORMAT='time: %3R' \
                 bash -c 'time mamba env update -p {0} -f "{1}" && \
                 time mamba clean --all -f -y && \
                 mamba list -p {0} \


### PR DESCRIPTION
https://github.com/jupyterhub/repo2docker/pull/962 added some shell `time` statements for analysing performance.

One of the many hidden features of bash is the ability to [customise the format of the displayed time](https://datacadamia.com/lang/bash/time). This PR changes it to show only the realtime in seconds:
```
...
Successfully installed jupyter-offlinenotebook-0.1.0
time: 2.548
+ /srv/conda/envs/notebook/bin/jupyter labextension install --no-build jupyter-offlinenotebook
time: 4.406
+ /srv/conda/envs/notebook/bin/jupyter lab build --minimize=False
[LabBuildApp] JupyterLab 2.2.0
[LabBuildApp] Building in /srv/conda/envs/notebook/share/jupyter/lab
[LabBuildApp] Building jupyterlab assets (build:prod)
time: 93.153
...
time: 0.936
...
time: 233.246
Removing intermediate container 1bcefe6062f8
 ---> 92ad32caccb0
...
```
With this more concise format I think it's fine to keep those `time` statements permanently, and to extend it to measuring other shell commands too.