### PR TITLE
WIP: s3 logs prototype

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup(
     name="jupyter-repo2docker",
     version=versioneer.get_version(),
     install_requires=[
+        "boto3",
         "docker",
         "traitlets",
         "python-json-logger",


### PR DESCRIPTION
Prototype of uploading repo2docker build logs to S3 (https://github.com/jupyterhub/binderhub/issues/1156)

If you don't have access to an S3 server run a local one:

    docker run -it --rm -e MINIO_ACCESS_KEY=minio -e MINIO_SECRET_KEY=minio123 -p 9000:9000 minio/minio server /data

Download an S3 client e.g. the [minio client](https://docs.min.io/docs/minio-client-quickstart-guide.html) from https://min.io/download

Add temporary client config called `mybindertest` for the local test server

    export MC_HOST_mybindertest=http://minio:minio123@localhost:9000
    
Create a bucket called `mybinder`

    mc mb mybindertest/mybinder

Allow public downloads from the bucket

    mc policy set download mybindertest/mybinder

Repo2docker S3 logs config

    cat << EOF > s3config.py 
    c.Repo2Docker.s3_logs_endpoint = 'http://localhost:9000'
    c.Repo2Docker.s3_logs_access_key = 'minio'
    c.Repo2Docker.s3_logs_secret_key = 'minio123'
    c.Repo2Docker.s3_logs_bucket = 'mybinder'
    EOF

Build with image name `asd123`

    repo2docker --config s3config.py --image-name asd123 https://github.com/binder-examples/requirements

Logs should be available at
http://localhost:9000/mybinder/buildlogs/asd123/repo2docker.log

If you can't be bothered to setup your own Minio server you can use the public demo one at play.min.io:

    export MC_HOST_mybindertest=https://Q3AM3UQ867SPQQA43P2F:zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG@play.min.io
    mc mb mybindertest/mybinder
    mc policy set download mybindertest/mybinder

Those demo credentials are public, I've already run the above so assuming no-one else has modified it you just need:

    cat << EOF > s3config.py 
    c.Repo2Docker.s3_logs_endpoint = 'https://play.min.io'
    c.Repo2Docker.s3_logs_access_key = 'Q3AM3UQ867SPQQA43P2F'
    c.Repo2Docker.s3_logs_secret_key = 'zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG'
    c.Repo2Docker.s3_logs_bucket = 'mybinder'
    EOF

    repo2docker --config s3config.py --no-run https://github.com/binder-examples/conda
    ...
    Successfully tagged r2dhttps-3a-2f-2fgithub-2ecom-2fbinder-2dexamples-2fconda0349319:latest
    Uploading log to mybinder/buildlogs/r2dhttps-3a-2f-2fgithub-2ecom-2fbinder-2dexamples-2fconda0349319/repo2docker.log


https://play.minio.io/mybinder/buildlogs/r2dhttps-3a-2f-2fgithub-2ecom-2fbinder-2dexamples-2fconda0349319/repo2docker.log