### PR TITLE
add chown to COPY commands to reduce layer count

### DIFF
--- a/repo2docker/buildpacks/base.py
+++ b/repo2docker/buildpacks/base.py
@@ -13,10 +13,11 @@ import xml.etree.ElementTree as ET
 
 from traitlets import Dict
 
+# Only use syntax features supported by Docker 17.09
 TEMPLATE = r"""
 FROM buildpack-deps:bionic
 
-# avoid prompts from apt
+# Avoid prompts from apt
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Set up locales properly
@@ -100,12 +101,12 @@ ENV PATH {{ ':'.join(path) }}:${PATH}
 {% if build_script_files -%}
 # If scripts required during build are present, copy them
 {% for src, dst in build_script_files|dictsort %}
-COPY --chown=${NB_USER}:${NB_USER} {{ src }} {{ dst }}
+COPY --chown={{ user }}:{{ user }} {{ src }} {{ dst }}
 {% endfor -%}
 {% endif -%}
 
 {% for sd in build_script_directives -%}
-{{sd}}
+{{ sd }}
 {% endfor %}
 
 # Allow target path repo is cloned to be configurable
@@ -137,7 +138,7 @@ ENV {{item[0]}} {{item[1]}}
 {% if preassemble_script_files -%}
 # If scripts required during build are present, copy them
 {% for src, dst in preassemble_script_files|dictsort %}
-COPY --chown=${NB_USER}:${NB_USER} src/{{ src }} ${REPO_DIR}/{{ dst }}
+COPY --chown={{ user }}:{{ user }} src/{{ src }} ${REPO_DIR}/{{ dst }}
 {% endfor -%}
 {% endif -%}
 
@@ -146,7 +147,7 @@ COPY --chown=${NB_USER}:${NB_USER} src/{{ src }} ${REPO_DIR}/{{ dst }}
 {% endfor %}
 
 # Copy stuff.
-COPY --chown=${NB_USER}:${NB_USER} src/ ${REPO_DIR}
+COPY --chown={{ user }}:{{ user }} src/ ${REPO_DIR}
 
 # Run assemble scripts! These will actually turn the specification
 # in the repository into an image.
@@ -194,6 +195,9 @@ CMD ["jupyter", "notebook", "--ip", "0.0.0.0"]
 ENTRYPOINT_FILE = os.path.join(
     os.path.dirname(os.path.abspath(__file__)), "repo2docker-entrypoint"
 )
+
+# Also used for the group
+DEFAULT_NB_UID = 1000
 
 
 class BuildPack:
@@ -499,10 +503,12 @@ class BuildPack:
     def detect(self):
         return True
 
-    def render(self):
+    def render(self, build_args=None):
         """
         Render BuildPack into Dockerfile
         """
+        build_args = build_args or {}
+
         t = jinja2.Template(TEMPLATE)
 
         build_script_directives = []
@@ -561,6 +567,8 @@ class BuildPack:
             post_build_scripts=self.get_post_build_scripts(),
             start_script=self.get_start_script(),
             appendix=self.appendix,
+            # For docker 17.09 `COPY --chown`, 19.03 would allow using $NBUSER
+            user=build_args.get("NB_UID", DEFAULT_NB_UID),
         )
 
     @staticmethod
@@ -604,7 +612,7 @@ class BuildPack:
         tarf = io.BytesIO()
         tar = tarfile.open(fileobj=tarf, mode="w")
         dockerfile_tarinfo = tarfile.TarInfo("Dockerfile")
-        dockerfile = self.render().encode("utf-8")
+        dockerfile = self.render(build_args).encode("utf-8")
         dockerfile_tarinfo.size = len(dockerfile)
 
         tar.addfile(dockerfile_tarinfo, io.BytesIO(dockerfile))
@@ -616,8 +624,8 @@ class BuildPack:
             # https://github.com/docker/docker-py/pull/1582 is related
             tar.uname = ""
             tar.gname = ""
-            tar.uid = int(build_args.get("NB_UID", 1000))
-            tar.gid = int(build_args.get("NB_UID", 1000))
+            tar.uid = int(build_args.get("NB_UID", DEFAULT_NB_UID))
+            tar.gid = int(build_args.get("NB_UID", DEFAULT_NB_UID))
             return tar
 
         for src in sorted(self.get_build_script_files()):

--- a/repo2docker/buildpacks/base.py
+++ b/repo2docker/buildpacks/base.py
@@ -100,7 +100,7 @@ ENV PATH {{ ':'.join(path) }}:${PATH}
 {% if build_script_files -%}
 # If scripts required during build are present, copy them
 {% for src, dst in build_script_files|dictsort %}
-COPY {{ src }} {{ dst }}
+COPY --chown=${NB_USER}:${NB_USER} {{ src }} {{ dst }}
 {% endfor -%}
 {% endif -%}
 
@@ -137,24 +137,16 @@ ENV {{item[0]}} {{item[1]}}
 {% if preassemble_script_files -%}
 # If scripts required during build are present, copy them
 {% for src, dst in preassemble_script_files|dictsort %}
-COPY src/{{ src }} ${REPO_DIR}/{{ dst }}
+COPY --chown=${NB_USER}:${NB_USER} src/{{ src }} ${REPO_DIR}/{{ dst }}
 {% endfor -%}
-{% endif -%}
-
-{% if preassemble_script_directives -%}
-USER root
-RUN chown -R ${NB_USER}:${NB_USER} ${REPO_DIR}
 {% endif -%}
 
 {% for sd in preassemble_script_directives -%}
 {{ sd }}
 {% endfor %}
 
-# Copy and chown stuff. This doubles the size of the repo, because
-# you can't actually copy as USER, only as root! Thanks, Docker!
-USER root
-COPY src/ ${REPO_DIR}
-RUN chown -R ${NB_USER}:${NB_USER} ${REPO_DIR}
+# Copy stuff.
+COPY --chown=${NB_USER}:${NB_USER} src/ ${REPO_DIR}
 
 # Run assemble scripts! These will actually turn the specification
 # in the repository into an image.

--- a/repo2docker/buildpacks/docker.py
+++ b/repo2docker/buildpacks/docker.py
@@ -14,7 +14,7 @@ class DockerBuildPack(BuildPack):
         """Check if current repo should be built with the Docker BuildPack"""
         return os.path.exists(self.binder_path("Dockerfile"))
 
-    def render(self):
+    def render(self, build_args=None):
         """Render the Dockerfile using by reading it from the source repo"""
         Dockerfile = self.binder_path("Dockerfile")
         with open(Dockerfile) as f:


### PR DESCRIPTION
Hi folks, thanks for repo2docker! :heart: 

In the generated Dockerfile, this combines a number of `COPY` and subsequent `USER` and `RUN chown` calls with the [`COPY --chown` syntax](https://docs.docker.com/engine/reference/builder/#copy).

Anecdotally, this seems to reduce the layer count a good deal: 45 vs 53 for one of the first tests that runs with just an `environment.yml`... my tests are still chugging, so I don't have a bunch of other data points, bless CI!

I haven't assessed the impact to size, but I would image it would result in a 2-1 reduction, as the `chown`ed files are, to my knowledge, copied in the subsequent layer. Can't hurt to look!

closes #164 
closes #861