### PR TITLE
[MRG] Ensure REPO_DIR owned by NB_USER

### DIFF
--- a/repo2docker/buildpacks/base.py
+++ b/repo2docker/buildpacks/base.py
@@ -113,6 +113,7 @@ COPY --chown={{ user }}:{{ user }} {{ src }} {{ dst }}
 ARG REPO_DIR=${HOME}
 ENV REPO_DIR ${REPO_DIR}
 WORKDIR ${REPO_DIR}
+RUN chown ${NB_USER}:${NB_USER} ${REPO_DIR}
 
 # We want to allow two things:
 #   1. If there's a .local/bin directory in the repo, things there

--- a/tests/conda/repo-path/verify
+++ b/tests/conda/repo-path/verify
@@ -13,5 +13,8 @@ assert sys.executable.startswith("/srv/conda/"), sys.executable
 assert os.path.exists("/srv/repo/verify")
 assert os.path.abspath(__file__) == "/srv/repo/verify"
 
+# Repo should be writable
+assert os.access("/srv/repo", os.W_OK)
+
 # We should be able to import the package in environment.yml
 import numpy


### PR DESCRIPTION
It is my take to fix #974 by making sure `REPO_DIR` owned by `NB_USER`. It was recently changed by #969 leaving `REPO_DIR` owned by root when `REPO_DIR` was set to a directory other than `$HOME` by using `--target-repo-dir` option.

closes #974