### PR TITLE
Allow REPO_DIR to be a non-existing folder by creating it and providing the user with permissions

### DIFF
--- a/repo2docker/buildpacks/base.py
+++ b/repo2docker/buildpacks/base.py
@@ -106,13 +106,10 @@ USER root
 # Allow target path repo is cloned to be configurable
 ARG REPO_DIR=${HOME}
 ENV REPO_DIR=${REPO_DIR}
-RUN if [ ! -d "${REPO_DIR}" ] \
-    ; then \
-        mkdir -p "${REPO_DIR}" \
-        && chown -R ${NB_USER}:${NB_USER} "${REPO_DIR}" \
-    ; else \
-        echo "${REPO_DIR} already exists..." \
-    ; fi
+# Create a folder and grant the user permissions if it doesn't exist
+RUN if [ ! -d "${REPO_DIR}" ]; then \
+        /usr/bin/install -o ${NB_USER} -g ${NB_USER} -d "${REPO_DIR}"; \
+    fi
 
 WORKDIR ${REPO_DIR}
 RUN chown ${NB_USER}:${NB_USER} ${REPO_DIR}

--- a/repo2docker/buildpacks/base.py
+++ b/repo2docker/buildpacks/base.py
@@ -105,7 +105,9 @@ USER root
 
 # Allow target path repo is cloned to be configurable
 ARG REPO_DIR=${HOME}
-ENV REPO_DIR ${REPO_DIR}
+RUN [ ! -d ${REPO_DIR} ] \
+    && mkdir -p ${REPO_DIR} \
+    && chown -R ${NB_USER}:${NB_USER} ${REPO_DIR}
 WORKDIR ${REPO_DIR}
 RUN chown ${NB_USER}:${NB_USER} ${REPO_DIR}
 
@@ -144,7 +146,7 @@ COPY --chown={{ user }}:{{ user }} src/{{ src }} ${REPO_DIR}/{{ dst }}
 USER root
 
 # Copy stuff.
-COPY --chown={{ user }}:{{ user }} src/ ${REPO_DIR}
+COPY --chown={{ user }}:{{ user }} src/ ${REPO_DIR}/
 
 # Run assemble scripts! These will actually turn the specification
 # in the repository into an image.

--- a/tests/conda/r3.6-target-repo-dir-flag/verify.py
+++ b/tests/conda/r3.6-target-repo-dir-flag/verify.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import sys
 import os
+from glob import glob
 
 # conda should still be in /srv/conda
 # and Python should still be in $NB_PYTHON_PREFIX
@@ -15,3 +16,12 @@ assert os.path.abspath(__file__) == "/srv/repo/verify.py"
 
 # Repo should be writable
 assert os.access("/srv/repo", os.W_OK)
+
+# All files in repo dir should be readable and writeable
+for path in glob("/src/repo/**/*", recursive=True):
+    assert os.access(path, os.R_OK)
+    assert os.access(path, os.W_OK)
+
+# Should be able to make a new file
+with open("/srv/repo/writeable", "w") as fp:
+    fp.write("writeable")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,19 @@
 """
 Custom test collector for our integration tests.
 
-Each directory that has a script named 'verify' is considered
-a test. jupyter-repo2docker is run on that directory,
-and then ./verify is run inside the built container. It should
-return a non-zero exit code for the test to be considered a
-success.
+
+Test lifecycle:
+- Find all directories that contain `verify` or `*.repos.yaml`
+- If `verify` is found:
+    - Run `jupyter-repo2docker` on the test directory.
+      - Extra arguments may be added as YAML list of strings in `extra-args.yaml`.
+    - Run `./verify` inside the built container.
+    - It should return a non-zero exit code for the test to be considered a
+      successful.
+- If a `*.repos.yaml` is found:
+    - For each entry of the form `{name, url, ref, verify}`
+        - Run `jupyter-repo2docker` with the `url` and `ref`
+        - Run the `verify` inside the built container
 """
 
 import os


### PR DESCRIPTION
## PR summary by Erik 2022-10-31

- __Non-existing REPO_DIR folder__
  If users provide a REPO_DIR as a build arg to a folder that doesn't exist, the root user will create it but leave the non-root user without permissions to access it. This PR resolves that and adds a test to verify it by adding some `mkdir` and `chown` statements.
- __Dockerfile refactoring__
  It includes basic refactoring of the Dockerfile to reduce the layers by coalescing ENV statements and making use of the recommended syntax with explicit `=` in ENV statements.
- __Refined test documentation__
  It updates a comment to clarify how the test suite works.

---

**Updated**

This PR (originally attempted to try out some alternatives to #974 and (#975) now:
- > changes the target dir TBD (might not, if #975 changes are sufficient: @manics and @tomyun offered some additional approaches to be considered/discussed)
- adds some additional read-/write-ability checks to the custom target dir test case
  - in the process of figuring out where to land it... 
    - expands the docs in `conftest.py` for providing extra arguments via `extra-args.yml`
- partially to offset layer addition for path checking, where possible... 
  - updates all uses of `ENV` to the [recommended `=` syntax](https://docs.docker.com/engine/reference/builder/#env), replacing use of the "alternative" (space-based) syntax:
    > The alternative syntax is supported for backward compatibility, but discouraged for the reasons outlined above, and may be removed in a future release.
  - combines multiple consecutive `ENV` calls to a single, multi-line directive

--- 
> original

> - fixes #974 (attempted)
> - alternative to #975

> ~~Some guidance on _where_ to test this would be helpful... looking through the examples, I didn't see a way to add cli args, e.g. a `repo2docker-cli-args` file, perhaps that would be useful? this could be piggybacked off any of the existing ones, then...~~

> I found :point_up: and added some docs in `conftest.py`. Since the conda example was already testing repo-dir, i just added the test in that place.