### PR TITLE
[MRG] Remove reference to `master` branch from CLI doc

### DIFF
--- a/repo2docker/__main__.py
+++ b/repo2docker/__main__.py
@@ -96,7 +96,8 @@ def get_argparser():
     argparser.add_argument(
         "--ref",
         help=(
-            "If building a git url, which reference to check out. " "E.g., `master`."
+            "Reference to build instead of default reference. For example"
+            " branch name or commit for a Git repository."
         ),
     )
 

--- a/repo2docker/contentproviders/git.py
+++ b/repo2docker/contentproviders/git.py
@@ -47,9 +47,18 @@ class Git(ContentProvider):
                 self.log.error(
                     "Failed to check out ref %s", ref, extra=dict(phase="failed")
                 )
-                raise ValueError("Failed to check out ref {}".format(ref))
+                if ref == "master":
+                    msg = (
+                        "Failed to check out the 'master' branch. "
+                        "Maybe the default branch is not named 'master' "
+                        "for this repository.\n\nTry not explicitly "
+                        "specifying `--ref`."
+                    )
+                else:
+                    msg = "Failed to check out ref {}".format(ref)
+                raise ValueError(msg)
             # We don't need to explicitly checkout things as the reset will
-            # take of that. If the hash is resolved above, we should be
+            # take care of that. If the hash is resolved above, we should be
             # able to reset to it
             for line in execute_cmd(
                 ["git", "reset", "--hard", hash], cwd=output_dir, capture=yield_output


### PR DESCRIPTION
Make repo2docker ready for the new default branch name on GitHub: `main`.

This already worked before and still works (bokeh renamed their default branch from `master` to `main` a while back):
```
# check out default branch (main)
$ repo2docker --no-build https://github.com/bokeh/bokeh-notebooks/
# uses old name, is redirected and checks out new default branch (main)
$ repo2docker --no-build --ref master https://github.com/bokeh/bokeh-notebooks/
```

A newly created repository that uses main as default branch name works:
```
repo2docker --no-build https://github.com/betatim/new-default-branch-name
# Newly created repo with main as default branch, raises exception
repo2docker --no-build --ref master https://github.com/betatim/new-default-branch-name
```

This PR only changes an error messages and a help text. I couldn't find any other explicit references to `master` as default branch name.

closes #971 