### PR TITLE
[MRG] Set JUPYTER_CONFIG_DIR

### DIFF
--- a/repo2docker/buildpacks/julia/julia_project.py
+++ b/repo2docker/buildpacks/julia/julia_project.py
@@ -78,6 +78,7 @@ class JuliaProjectTomlBuildPack(PythonBuildPack):
             ("JULIA_DEPOT_PATH", "${JULIA_PATH}/pkg"),
             ("JULIA_VERSION", self.julia_version),
             ("JUPYTER", "${NB_PYTHON_PREFIX}/bin/jupyter"),
+            ("JUPYTER_CONFIG_DIR", "${NB_PYTHON_PREFIX}/etc/jupyter"),
             ("JUPYTER_DATA_DIR", "${NB_PYTHON_PREFIX}/share/jupyter"),
         ]
 


### PR DESCRIPTION
This is for Julia build pack. For consistency with `JUPYTER_DATA_DIR` which is already set to our custom non-home directory (`/srv/conda/envs/notebook/share/jupyter`), this PR sets `JUPYTER_CONFIG_DIR` to a similar location (`/srv/conda/envs/notebook/etc/jupyter`). These settings are listed in the [Jupyter documentation](https://jupyter.readthedocs.io/en/latest/use/jupyter-directories.html).

It would be particularly useful in the scenario when user home is mounted to a persistent volume as with a typical JupyterHub environment. Without this `JUPYTER_CONFIG_DIR`, any settings, especially for custom notebook/lab extensions, would be stored in the home directory by default and they would not be available on runtime when the home is replaced by another volume.