### PR TITLE
[MRG] Experiment with different install mechanism to get code coverage stats again

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,5 +1,7 @@
-# show coverage in CI status, not as a comment. 
+# show coverage in CI status, not as a comment.
 comment: off
+fixes:
+  - "*/site-packages/::"
 coverage:
   status:
     project:
@@ -7,4 +9,4 @@ coverage:
         target: auto
     patch:
       default:
-        target: 20% 
+        target: 20%

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,11 @@
 [run]
 # this file comes from versioneer and we don't test it
 omit = */_version.py
+
+[paths]
+# This tells coverage how to combine results together or said differently
+# which files at different paths are actually the same file
+# documented at https://coverage.readthedocs.io/en/latest/config.html#paths
+source =
+    repo2docker/
+    /opt/hostedtoolcache/Python/*/site-packages/repo2docker

--- a/.coveragerc
+++ b/.coveragerc
@@ -6,6 +6,11 @@ omit = */_version.py
 # This tells coverage how to combine results together or said differently
 # which files at different paths are actually the same file
 # documented at https://coverage.readthedocs.io/en/latest/config.html#paths
+# Yes, we list repo2docker twice here. This allows you to install repo2docker
+# with `pip install -e.` for local development and from the wheel (as done on
+# CI) and get `repo2docker/foo.py` as paths in the coverage report
 source =
-    repo2docker/
-    /opt/hostedtoolcache/Python/*/site-packages/repo2docker
+    repo2docker
+    repo2docker
+    ../repo2docker
+    */site-packages/repo2docker

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -114,7 +114,10 @@ jobs:
 
       - name: "Run tests"
         run: |
-          pytest --durations 10 --cov repo2docker -v tests/${{ matrix.repo_type }}
+          cd tests
+          pytest --durations 10 --cov repo2docker -v ${{ matrix.repo_type }}
 
       # Action Repo: https://github.com/codecov/codecov-action
       - uses: codecov/codecov-action@v1
+        with:
+          directory: ./tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -120,4 +120,5 @@ jobs:
       - name: "Upload code coverage stats"
         run: |
           pip install codecov
-          pushd tests && codecov && popd
+          pushd tests && codecov && cat
+          cat /home/runner/work/repo2docker/repo2docker/tests/coverage.xml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -119,5 +119,6 @@ jobs:
 
       # Action Repo: https://github.com/codecov/codecov-action
       - uses: codecov/codecov-action@v1
+        working-directory: ./tests
         with:
           directory: ./tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -117,8 +117,7 @@ jobs:
           cd tests
           pytest --durations 10 --cov repo2docker -v ${{ matrix.repo_type }}
 
-      # Action Repo: https://github.com/codecov/codecov-action
-      - uses: codecov/codecov-action@v1
-        working-directory: ./tests
-        with:
-          directory: ./tests
+      - name: "Upload code coverage stats"
+        run: |
+          pip install codecov
+          pushd tests && codecov && popd

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -106,8 +106,7 @@ jobs:
           pip install --upgrade setuptools pip wheel
           pip install --upgrade -r dev-requirements.txt
           python setup.py bdist_wheel
-          #pip install dist/*.whl
-          pip install -e.
+          pip install dist/*.whl
           pip freeze
           # hg-evolve pinned to 9.2 because hg-evolve dropped support for
           # hg 4.5, installed with apt in Ubuntu 18.04

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -106,7 +106,8 @@ jobs:
           pip install --upgrade setuptools pip wheel
           pip install --upgrade -r dev-requirements.txt
           python setup.py bdist_wheel
-          pip install dist/*.whl
+          #pip install dist/*.whl
+          pip install -e.
           pip freeze
           # hg-evolve pinned to 9.2 because hg-evolve dropped support for
           # hg 4.5, installed with apt in Ubuntu 18.04


### PR DESCRIPTION
(New comment from January 2020: https://github.com/jupyterhub/repo2docker/pull/982#issuecomment-765900791 if you like to skip ahead read that, for a historical perspective keep reading here.)

---

For some reason we report zero coverage from our tests.

For example here https://github.com/jupyterhub/repo2docker/runs/1297097310

All the files in `repo2docker/...` appear to have zero coverage and the file in `/opt/hostedtoolcache/Python/3.8.6/x64/lib/python3.8/site-packages/repo2docker/...` do have some coverage. However when you look at what arrives in codecov you are at zero percent https://codecov.io/github/jupyterhub/repo2docker/commit/30ef2209cc767826e2647886854fac12469a06c1