### PR TITLE
[MRG] Update to node 14

### DIFF
--- a/repo2docker/buildpacks/base.py
+++ b/repo2docker/buildpacks/base.py
@@ -57,8 +57,8 @@ RUN groupadd \
 
 RUN wget --quiet -O - https://deb.nodesource.com/gpgkey/nodesource.gpg.key |  apt-key add - && \
     DISTRO="bionic" && \
-    echo "deb https://deb.nodesource.com/node_10.x $DISTRO main" >> /etc/apt/sources.list.d/nodesource.list && \
-    echo "deb-src https://deb.nodesource.com/node_10.x $DISTRO main" >> /etc/apt/sources.list.d/nodesource.list
+    echo "deb https://deb.nodesource.com/node_14.x $DISTRO main" >> /etc/apt/sources.list.d/nodesource.list && \
+    echo "deb-src https://deb.nodesource.com/node_14.x $DISTRO main" >> /etc/apt/sources.list.d/nodesource.list
 
 # Base package installs are not super interesting to users, so hide their outputs
 # If install fails for some reason, errors will still be printed

--- a/tests/base/node/README.md
+++ b/tests/base/node/README.md
@@ -1,0 +1,1 @@
+Test that node 12 and npm 6 are installed and runnable.

--- a/tests/base/node/verify
+++ b/tests/base/node/verify
@@ -5,7 +5,7 @@ set -ex
 # check node system package and its version
 which node
 node --version
-node --version | grep v10
+node --version | grep v14
 
 which npm
 npm --version

--- a/tests/base/node10/README.md
+++ b/tests/base/node10/README.md
@@ -1,1 +1,0 @@
-Test that node 10 and npm 6 are installed and runnable.


### PR DESCRIPTION
According to the Releases page, node 10 will soon be out of maintenance:

https://nodejs.org/en/about/releases/

![image](https://user-images.githubusercontent.com/591645/98401291-bb3c2980-2065-11eb-8671-c79325a226e6.png)

This change bumps the node version to 14.

Also for extra context: starting from https://github.com/jupyterlab/jupyterlab/pull/9282, JupyterLab requires node>=12, which currently makes the Binder preview builds fail: https://github.com/jupyterlab/jupyterlab/pull/9296#issuecomment-723226359