### PR TITLE
[MRG] Stream jupyter server logs to a file

### DIFF
--- a/repo2docker/buildpacks/repo2docker-entrypoint
+++ b/repo2docker/buildpacks/repo2docker-entrypoint
@@ -19,3 +19,6 @@ if [[ ! -z "${R2D_ENTRYPOINT:-}" ]]; then
 else
     exec "$@" >&"$log_fd" 2>&1
 fi
+
+# Close the loggging output aggain
+exec {log_fd}>&-

--- a/repo2docker/buildpacks/repo2docker-entrypoint
+++ b/repo2docker/buildpacks/repo2docker-entrypoint
@@ -15,10 +15,10 @@ if [[ ! -z "${R2D_ENTRYPOINT:-}" ]]; then
     if [[ ! -x "$R2D_ENTRYPOINT" ]]; then
         chmod u+x "$R2D_ENTRYPOINT"
     fi
-    exec "$R2D_ENTRYPOINT" "$@" >&"$log_fd" 2>&1
+    exec "$R2D_ENTRYPOINT" "$@" >&"$log_fd"
 else
-    exec "$@" >&"$log_fd" 2>&1
+    exec "$@" >&"$log_fd"
 fi
 
-# Close the loggging output aggain
-exec {log_fd}>&-
+# Close the logging output again
+#exec {log_fd}>&-

--- a/repo2docker/buildpacks/repo2docker-entrypoint
+++ b/repo2docker/buildpacks/repo2docker-entrypoint
@@ -2,11 +2,19 @@
 # lightest possible entrypoint that ensures that
 # we use a login shell to get a fully configured shell environment
 # (e.g. sourcing /etc/profile.d, ~/.bashrc, and friends)
+
+# Setup a file descriptor (FD) that is connected to a tee process which
+# writes its input to $REPO_DIR/.jupyter-server-log.txt
+# We later use this FD as a place to redirect the output of the actual
+# command to. We can't add `tee` to the command directly as that will prevent
+# the container from exiting when `docker stop` is run.
+exec {log_fd}> >(exec tee $REPO_DIR/.jupyter-server-log.txt)
+
 if [[ ! -z "${R2D_ENTRYPOINT:-}" ]]; then
     if [[ ! -x "$R2D_ENTRYPOINT" ]]; then
         chmod u+x "$R2D_ENTRYPOINT"
     fi
-    exec "$R2D_ENTRYPOINT" "$@"
+    exec "$R2D_ENTRYPOINT" "$@" >&"$log_fd" 2>&1
 else
-    exec "$@"
+    exec "$@" >&"$log_fd" 2>&1
 fi

--- a/repo2docker/buildpacks/repo2docker-entrypoint
+++ b/repo2docker/buildpacks/repo2docker-entrypoint
@@ -8,6 +8,7 @@
 # We later use this FD as a place to redirect the output of the actual
 # command to. We can't add `tee` to the command directly as that will prevent
 # the container from exiting when `docker stop` is run.
+# See https://stackoverflow.com/a/55678435
 exec {log_fd}> >(exec tee $REPO_DIR/.jupyter-server-log.txt)
 
 if [[ ! -z "${R2D_ENTRYPOINT:-}" ]]; then

--- a/tests/unit/test_env.py
+++ b/tests/unit/test_env.py
@@ -58,6 +58,10 @@ def test_env():
 
     # all docker output is returned by repo2docker on stderr
     # extract just the declare for better failure message formatting
+    # stdout should be empty
+    assert not result.stdout
+
+    # stderr should contain lines of output
     declares = [x for x in result.stderr.split("\n") if x.startswith("declare")]
     assert 'declare -x FOO="{}"'.format(ts) in declares
     assert 'declare -x BAR="baz"' in declares


### PR DESCRIPTION
By streaming the logs also to a file users can access them from inside
the container which helps them debug issues without having to ask an
admin.

Follow up from https://github.com/jupyterhub/binderhub/issues/1156#issuecomment-703448118

<!--

Our guide to getting a PR merged https://repo2docker.readthedocs.io/en/latest/contributing/contributing.html#guidelines-to-getting-a-pull-request-merged.

About to propose a big change? Read https://repo2docker.readthedocs.io/en/latest/contributing/contributing.html#process-for-making-a-contribution to maximise the chances of it getting merged quickly.

-->
