### PR TITLE
buildpacks/nix: disable sandboxing (bugfix)

### DIFF
--- a/repo2docker/buildpacks/nix/__init__.py
+++ b/repo2docker/buildpacks/nix/__init__.py
@@ -23,17 +23,22 @@ class NixBuildPack(BaseImage):
         """
         Return series of build-steps common to all nix repositories.
         Notice how only root privileges are needed for creating nix
-        directory.
+        directory and a nix.conf file.
 
          - create nix directory for user nix installation
+         - disable sandboxing because its unsupported inside a Docker container
          - install nix package manager for user
+
         """
         return super().get_build_scripts() + [
             (
                 "root",
                 """
             mkdir -m 0755 /nix && \
-            chown -R ${NB_USER}:${NB_USER} /nix /usr/local/bin/nix-shell-wrapper /home/${NB_USER}
+            chown -R ${NB_USER}:${NB_USER} /nix /usr/local/bin/nix-shell-wrapper /home/${NB_USER} && \
+            mkdir -p /etc/nix && \
+            touch /etc/nix/nix.conf && \
+            echo "sandbox = false" >> /etc/nix/nix.conf
             """,
             ),
             (

--- a/tests/nix/test-building/README.rst
+++ b/tests/nix/test-building/README.rst
@@ -1,0 +1,4 @@
+Check that we can build
+-----------------------
+
+Test that actual building instead of substituting (downloading an existing build) works.

--- a/tests/nix/test-building/default.nix
+++ b/tests/nix/test-building/default.nix
@@ -1,0 +1,27 @@
+let
+  # Pinning nixpkgs to specific release
+  # To get sha256 use "nix-prefetch-git <url> --rev <commit>"
+  commitRev="5574b6a152b1b3ae5f93ba37c4ffd1981f62bf5a";
+  nixpkgs = builtins.fetchTarball {
+    url = "https://github.com/NixOS/nixpkgs/archive/${commitRev}.tar.gz";
+    sha256 = "1pqdddp4aiz726c7qs1dwyfzixi14shp0mbzi1jhapl9hrajfsjg";
+  };
+  pkgs = import nixpkgs { config = { allowUnfree = true; }; };
+
+  # Test that we can actually build
+  test-build = pkgs.runCommand "test-build" { } ''
+    touch $out
+  '';
+
+in
+pkgs.mkShell {
+  buildInputs = with pkgs; [
+    python36Packages.numpy
+    python36Packages.notebook
+    test-build
+  ];
+
+  shellHook = ''
+    export NIX_PATH="nixpkgs=${nixpkgs}:."
+  '';
+}

--- a/tests/nix/test-building/verify
+++ b/tests/nix/test-building/verify
@@ -1,0 +1,3 @@
+#!/usr/bin/env python
+
+import numpy


### PR DESCRIPTION
<!--

Our guide to getting a PR merged https://repo2docker.readthedocs.io/en/latest/contributing/contributing.html#guidelines-to-getting-a-pull-request-merged.

About to propose a big change? Read https://repo2docker.readthedocs.io/en/latest/contributing/contributing.html#process-for-making-a-contribution to maximise the chances of it getting merged quickly.

-->

The version bump #915 broke the Nix buildpack in case one does a build.

Nix 2.3 enables sandboxing by default. Building inside a Docker
container, while Nix is having sandboxing enabled is not possible. Thus,
sandbox = false should be set in /etc/nix/nix.conf.

cc @costrouc 
