### PR TITLE
[MRG] Fetch available Julia versions from hosted json

### DIFF
--- a/repo2docker/buildpacks/julia/julia_project.py
+++ b/repo2docker/buildpacks/julia/julia_project.py
@@ -18,9 +18,12 @@ class JuliaProjectTomlBuildPack(PythonBuildPack):
     @property
     @functools.lru_cache(maxsize=1)
     def all_julias(self):
-        json = requests.get(
-            "https://julialang-s3.julialang.org/bin/versions.json"
-        ).json()
+        try:
+            json = requests.get(
+                "https://julialang-s3.julialang.org/bin/versions.json"
+            ).json()
+        except Exception as e:
+            raise RuntimeError("Failed to fetch available Julia versions: {e}")
         vers = [semver.VersionInfo.parse(v) for v in json.keys()]
         # filter out pre-release versions not supported by find_semver_match()
         filtered_vers = [v for v in vers if v.prerelease is None]

--- a/repo2docker/buildpacks/julia/julia_project.py
+++ b/repo2docker/buildpacks/julia/julia_project.py
@@ -41,18 +41,18 @@ class JuliaProjectTomlBuildPack(PythonBuildPack):
         else:
             project_toml = toml.load(self.binder_path("Project.toml"))
 
-        if "compat" in project_toml:
-            if "julia" in project_toml["compat"]:
-                julia_version_str = project_toml["compat"]["julia"]
+        try:
+            # For Project.toml files, install the latest julia version that
+            # satisfies the given semver.
+            compat = project_toml["compat"]["julia"]
+        except:
+            # Default version which needs to be manually updated with new major.minor releases
+            compat = "1.5"
 
-                # For Project.toml files, install the latest julia version that
-                # satisfies the given semver.
-                _julia_version = find_semver_match(julia_version_str, self.all_julias)
-                if _julia_version is not None:
-                    return _julia_version
-
-        default_julia_version = self.all_julias[-1]
-        return default_julia_version
+        match = find_semver_match(compat, self.all_julias)
+        if match is None:
+            raise RuntimeError("Failed to find a matching Julia version: {compat}")
+        return match
 
     def get_build_env(self):
         """Get additional environment settings for Julia and Jupyter

--- a/repo2docker/buildpacks/julia/semver.py
+++ b/repo2docker/buildpacks/julia/semver.py
@@ -113,7 +113,8 @@ class SemverMatcher:
         while len(v) < 3:
             v = v + (0,)
         v_str = ".".join(map(str, v))
-        return semver.match(v_str, self.constraint_str)
+        v_ver = semver.VersionInfo.parse(v_str)
+        return semver.VersionInfo.match(v_ver, self.constraint_str)
 
     def __eq__(self, rhs):
         return self.constraint_str == rhs.constraint_str


### PR DESCRIPTION
Instead of adding hard-coded version strings whenever a new release comes out, this PR fetches a list of currently available Julia versions from officially hosted [JSON](https://julialang-s3.julialang.org/bin/versions.json) file (JuliaLang/www.julialang.org#1101).

1. The resulting list `all_julias` should cover the same range we used to have, except it now contains more versions starting from 0.1.2, not 0.7.0 as we have now. I don't think this would cause a problem though as any projects relying on old 0.x versions would use REQUIRE file covered by julia_require.py.

2. Setting `default_julia_version` from `all_julias` is pushed back to the end of `julia_version` property to minimize json requests.

3. I noticed that our `find_semver_match()` is currently not fully compatible with [Pkg.jl compat specifiers](https://julialang.github.io/Pkg.jl/v1.5/compatibility/). For example,  `"= 1.2.3"` with space would result into an error with repo2docker. We also don't support pre-release strings like `"1.5.0-rc1"`. We may address these issues in a separate PR later on.