### PR TITLE
Update jupyter-offlinenotebook to 0.2.1

### DIFF
--- a/repo2docker/buildpacks/conda/install-miniforge.bash
+++ b/repo2docker/buildpacks/conda/install-miniforge.bash
@@ -51,7 +51,7 @@ time mamba env create -p ${NB_PYTHON_PREFIX} -f /tmp/environment.yml
 # Install jupyter-offline-notebook to allow users to download notebooks
 # after the server connection has been lost
 # This will install and enable the extension for jupyter notebook and JupyterLab 3
-time ${NB_PYTHON_PREFIX}/bin/python -m pip install jupyter-offlinenotebook==0.2.0
+time ${NB_PYTHON_PREFIX}/bin/python -m pip install jupyter-offlinenotebook==0.2.1
 # and this installs it for lab 2. Keep going if the lab version is incompatible
 # with the extension.
 # Don't minimize build as it may fail, possibly due to excessive resource usage

--- a/repo2docker/buildpacks/conda/install-miniforge.bash
+++ b/repo2docker/buildpacks/conda/install-miniforge.bash
@@ -50,9 +50,9 @@ time mamba env create -p ${NB_PYTHON_PREFIX} -f /tmp/environment.yml
 
 # Install jupyter-offline-notebook to allow users to download notebooks
 # after the server connection has been lost
-# This will install and enable the extension for jupyter notebook
-time ${NB_PYTHON_PREFIX}/bin/python -m pip install jupyter-offlinenotebook==0.1.0
-# and this installs it for lab. Keep going if the lab version is incompatible
+# This will install and enable the extension for jupyter notebook and JupyterLab 3
+time ${NB_PYTHON_PREFIX}/bin/python -m pip install jupyter-offlinenotebook==0.2.0
+# and this installs it for lab 2. Keep going if the lab version is incompatible
 # with the extension.
 # Don't minimize build as it may fail, possibly due to excessive resource usage
 # https://discourse.jupyter.org/t/tip-binder-jupyterlab-extension/6022


### PR DESCRIPTION
This includes the JupyterLab 3 extension that does not require a build step. It remains compatible with JupyterLab 2 (but the extension must be installed separately).

As far as JupyterLab 2 is concerned there is no change. For JupyterLab3 the extension is effectively pre-installed since it's part of the PyPI package, so it should "just work" if someone choose to install JupyterLab 3.

See also:
- https://github.com/jupyterlab/jupyterlab-demo/pull/102#issuecomment-754188038
- https://github.com/jupyterhub/repo2docker/pull/996