### PR TITLE
[MRG] Weekly test of master to check for external failures

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,10 +7,13 @@
 
 name: Continuous Integration
 
-# Only trigger the workflow when pushing to master
 on:
-  - push
-  - pull_request
+  push:
+  pull_request:
+  schedule:
+    # Weekly test so we know if tests break for external reasons
+    # https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#scheduled-events
+    - cron: '36 10 * * 0'
 
 # Global environment variables
 env:


### PR DESCRIPTION
Test failures in PRs can sometimes be quite hard to debug. By adding a weekly automated test run of the default branch we'll have a bit more information on whether a PR is failing due to a change in that PR or due to some external factor. I've chosen Sunday, the time `10:36` was picked using `$RANDOM`.