### PR TITLE
Investigating the missing logs

### DIFF
--- a/repo2docker/buildpacks/repo2docker-entrypoint
+++ b/repo2docker/buildpacks/repo2docker-entrypoint
@@ -15,10 +15,10 @@ if [[ ! -z "${R2D_ENTRYPOINT:-}" ]]; then
     if [[ ! -x "$R2D_ENTRYPOINT" ]]; then
         chmod u+x "$R2D_ENTRYPOINT"
     fi
-    exec "$R2D_ENTRYPOINT" "$@" >&"$log_fd"
+    exec "$R2D_ENTRYPOINT" "$@" 2>&1 >&"$log_fd"
 else
-    exec "$@" >&"$log_fd"
+    exec "$@" 2>&1 >&"$log_fd"
 fi
 
 # Close the logging output again
-#exec {log_fd}>&-
+exec {log_fd}>&-

--- a/tests/unit/test_env.py
+++ b/tests/unit/test_env.py
@@ -42,13 +42,15 @@ def test_env():
                 # value
                 "--env",
                 "SPAM_2=",
-                "--",
+                # "--",
                 tmpdir,
                 "/bin/bash",
                 "-c",
                 # Docker exports all passed env variables, so we can
                 # just look at exported variables.
-                "export",
+                "export; sleep 1",
+                # "export; echo TIMDONE",
+                # "export",
             ],
             universal_newlines=True,
             stdout=subprocess.PIPE,
@@ -60,6 +62,9 @@ def test_env():
     # extract just the declare for better failure message formatting
     # stdout should be empty
     assert not result.stdout
+
+    print(result.stderr.split("\n"))
+    # assert False
 
     # stderr should contain lines of output
     declares = [x for x in result.stderr.split("\n") if x.startswith("declare")]


### PR DESCRIPTION
This is a follow up to #987 

As we observed there the `test_env.py` tests break. Locally this also happens, but only sometimes. After about half a day of messing around and trying to figure out where the logs go I am resigning myself to not being able to figure it out :-/

It seems even with somewhat "extreme" measures like in the PR you either get the logs from the command executed (both in the "normal" logs and the newly added "late logs" or you don't get them in either).

A thing that seems to help is to add a `; sleep 1` to the command the test runs.

This makes me think that the issue is related to buffering of some kind, some where. I am tempted to suggest we add the `sleep` to the test and assume that the flakeyness is due to the very short execution time of the container, which isn't typical for repo2docker containers.

Unfortunately I don't understand enough about how the logging in docker works to know if changing config options in the logging driver https://docs.docker.com/config/containers/logging/configure/ would help or not :-/

A popular google result regarding "my docker logs are missing" is a note that journald rate limits log producers but I think this doesn't apply to us because I am running OSX. This means I don't have journald and as far as I understand it the default is logging driver is the `json-file` driver which doesn't use journald.

Thoughts welcome on how to fix this properly or the workaround.