### PR TITLE
fix dataverse regression introduced in last release

### DIFF
--- a/repo2docker/contentproviders/dataverse.py
+++ b/repo2docker/contentproviders/dataverse.py
@@ -73,7 +73,7 @@ class Dataverse(DoiProvider):
                 parsed_url._replace(path="/api/search", query=search_query)
             )
             self.log.debug("Querying Dataverse: " + search_url)
-            data = self.urlopen(search_url).json()
+            data = self.urlopen(search_url).json()["data"]
             if data["count_in_response"] != 1:
                 self.log.debug(
                     "Dataverse search query failed!\n - doi: {}\n - url: {}\n - resp: {}\n".format(
@@ -103,7 +103,7 @@ class Dataverse(DoiProvider):
         )
 
         resp = self.urlopen(url, headers={"accept": "application/json"})
-        record = resp.json()
+        record = resp.json()["data"]
 
         for fobj in deep_get(record, "latestVersion.files"):
             file_url = "{}/api/access/datafile/{}".format(

--- a/tests/unit/contentproviders/test_dataverse.py
+++ b/tests/unit/contentproviders/test_dataverse.py
@@ -60,8 +60,10 @@ def test_detect_dataverse(test_input, expected, requests_mock):
     requests_mock.get(
         "https://dataverse.harvard.edu/api/search?q=entityId:3323458&type=file",
         json={
-            "count_in_response": 1,
-            "items": [{"dataset_persistent_id": "doi:10.7910/DVN/6ZXAGT"}],
+            "data": {
+                "count_in_response": 1,
+                "items": [{"dataset_persistent_id": "doi:10.7910/DVN/6ZXAGT"}],
+            }
         },
     )
 
@@ -109,20 +111,22 @@ def dv_files(tmpdir):
 
 def test_dataverse_fetch(dv_files, requests_mock):
     mock_response = {
-        "latestVersion": {
-            "files": [
-                {"dataFile": {"id": 1}, "label": "some-file.txt"},
-                {
-                    "dataFile": {"id": 2},
-                    "label": "some-other-file.txt",
-                    "directoryLabel": "directory",
-                },
-                {
-                    "dataFile": {"id": 3},
-                    "label": "the-other-file.txt",
-                    "directoryLabel": "directory/subdirectory",
-                },
-            ]
+        "data": {
+            "latestVersion": {
+                "files": [
+                    {"dataFile": {"id": 1}, "label": "some-file.txt"},
+                    {
+                        "dataFile": {"id": 2},
+                        "label": "some-other-file.txt",
+                        "directoryLabel": "directory",
+                    },
+                    {
+                        "dataFile": {"id": 3},
+                        "label": "the-other-file.txt",
+                        "directoryLabel": "directory/subdirectory",
+                    },
+                ]
+            }
         }
     }
 


### PR DESCRIPTION
A regression was introduced in https://github.com/jupyterhub/repo2docker/pull/993 which broke the Dataverse build process.

This should fix https://github.com/jupyterhub/binderhub/issues/1263 (the repo builds locally now).

also should there be a test for this?