### PR TITLE
bump python in circleci  test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
   build_docs:
     # This is the base environment that Circle will use
     docker:
-      - image: circleci/python:3.6-stretch
+      - image: circleci/python:3.8-buster
     steps:
       # Get our data and merge with upstream
       - run: sudo apt-get update


### PR DESCRIPTION
Should get that back to passing

SHouldn't these be redundant with readthedocs tests? I see we have rtd PR tests enabled, but I haven't seen CI results from rtd in a while. I'm not sure how to debug that