### PR TITLE
Refine buffered output debugging

### DIFF
--- a/repo2docker/app.py
+++ b/repo2docker/app.py
@@ -19,7 +19,6 @@ import time
 from urllib.parse import urlparse
 
 import escapism
-from iso8601 import parse_date
 from pythonjsonlogger import jsonlogger
 
 from traitlets import Any, Dict, Int, List, Unicode, Bool, default
@@ -650,13 +649,6 @@ class Repo2Docker(Application):
                 "Container finished running.\n".upper(), extra=dict(phase="running")
             )
             # are there more logs? Let's send them back too
-            if last_timestamp:
-                # docker only accepts integer timestamps
-                # this means we will usually replay logs from the last second
-                # of the container
-                # we should check if this ever returns anything new,
-                # since we know it ~always returns something redundant
-                last_timestamp = int(parse_date(last_timestamp).timestamp())
             late_logs = container.logs(since=last_timestamp).decode("utf-8")
             for line in late_logs.split("\n"):
                 self.log.debug(line + "\n", extra=dict(phase="running"))

--- a/repo2docker/docker.py
+++ b/repo2docker/docker.py
@@ -13,8 +13,8 @@ class DockerContainer(Container):
     def reload(self):
         return self._c.reload()
 
-    def logs(self, *, stream=False):
-        return self._c.logs(stream=stream)
+    def logs(self, *, stream=False, timestamps=False, since=None):
+        return self._c.logs(stream=stream, timestamps=timestamps, since=since)
 
     def kill(self, *, signal="KILL"):
         return self._c.kill(signal=signal)

--- a/repo2docker/docker.py
+++ b/repo2docker/docker.py
@@ -3,6 +3,8 @@ Docker container engine for repo2docker
 """
 
 import docker
+from iso8601 import parse_date
+
 from .engine import Container, ContainerEngine, ContainerEngineException, Image
 
 
@@ -14,6 +16,13 @@ class DockerContainer(Container):
         return self._c.reload()
 
     def logs(self, *, stream=False, timestamps=False, since=None):
+        if since:
+            # docker only accepts integer timestamps
+            # this means we will usually replay logs from the last second
+            # of the container
+            # we should check if this ever returns anything new,
+            # since we know it ~always returns something redundant
+            since = int(parse_date(since).timestamp())
         return self._c.logs(stream=stream, timestamps=timestamps, since=since)
 
     def kill(self, *, signal="KILL"):

--- a/repo2docker/engine.py
+++ b/repo2docker/engine.py
@@ -21,7 +21,7 @@ class Container(ABC):
         """
 
     @abstractmethod
-    def logs(self, *, stream=False):
+    def logs(self, *, stream=False, timestamps=False, since=None):
         """
         Get the container logs.
 
@@ -29,6 +29,13 @@ class Container(ABC):
         ----------
         stream : bool
             If `True` return an iterator over the log lines, otherwise return all logs
+        timestamps : bool
+            If `True` log lines will be prefixed with iso8601 timestamps followed by space
+        since : int
+            An integer timestamp.
+            Can be constructed by parsing timestamps in prefixed lines issued when `timestamps=True`.
+            If given, start logs from this point,
+            instead of from container start.
 
         Returns
         -------

--- a/repo2docker/engine.py
+++ b/repo2docker/engine.py
@@ -31,9 +31,11 @@ class Container(ABC):
             If `True` return an iterator over the log lines, otherwise return all logs
         timestamps : bool
             If `True` log lines will be prefixed with iso8601 timestamps followed by space
-        since : int
-            An integer timestamp.
-            Can be constructed by parsing timestamps in prefixed lines issued when `timestamps=True`.
+        since : str
+            A timestamp string
+            Should be in the same format as the timestamp prefix given
+            when `timestamps=True`
+
             If given, start logs from this point,
             instead of from container start.
 

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ setup(
         "docker",
         "entrypoints",
         "escapism",
+        "iso8601",
         "jinja2",
         "python-json-logger",
         "requests",


### PR DESCRIPTION
Shouldn't change much, but a refinement of #1008

- use `since` when fetching late logs to reduce duplicated output (does not eliminate it due to required integer-second rounding of timestamps; requires UTC timestamp parsing not in the Python stdlib. :sigh:)
- demote late logs to debug-level, since they may not include any new output at all, and always include redundant output
- use capfd to capture output in test_env for easier debugging