### PR TITLE
Set default Julia version to 1.6

### DIFF
--- a/repo2docker/buildpacks/julia/julia_project.py
+++ b/repo2docker/buildpacks/julia/julia_project.py
@@ -47,7 +47,7 @@ class JuliaProjectTomlBuildPack(PythonBuildPack):
             compat = project_toml["compat"]["julia"]
         except:
             # Default version which needs to be manually updated with new major.minor releases
-            compat = "1.5"
+            compat = "1.6"
 
         match = find_semver_match(compat, self.all_julias)
         if match is None:


### PR DESCRIPTION
[Julia 1.6](https://julialang.org/blog/2021/03/julia-1.6-highlights/) just released.