### PR TITLE
Fix regression in hydroshare introduced after moving to requests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -110,7 +110,8 @@ jobs:
           pip freeze
           # hg-evolve pinned to 9.2 because hg-evolve dropped support for
           # hg 4.5, installed with apt in Ubuntu 18.04
-          $(hg debuginstall --template "{pythonexe}") -m pip install hg-evolve==9.2 --user
+          pip install mercurial
+          $(hg debuginstall --template "{pythonexe}") -m pip install hg-evolve --user
 
       - name: "Run tests"
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -110,8 +110,8 @@ jobs:
           pip freeze
           # hg-evolve pinned to 9.2 because hg-evolve dropped support for
           # hg 4.5, installed with apt in Ubuntu 18.04
-          pip install mercurial
-          $(hg debuginstall --template "{pythonexe}") -m pip install hg-evolve --user
+          $(hg debuginstall --template "{pythonexe}") -m pip install setuptools --user
+          $(hg debuginstall --template "{pythonexe}") -m pip install hg-evolve==9.2 --user
 
       - name: "Run tests"
         run: |

--- a/repo2docker/contentproviders/hydroshare.py
+++ b/repo2docker/contentproviders/hydroshare.py
@@ -67,8 +67,8 @@ class Hydroshare(DoiProvider):
         conn = self.urlopen(bag_url)
         total_wait_time = 0
         while (
-            conn.getcode() == 200
-            and conn.info().get_content_type() != "application/zip"
+            conn.status_code == 200
+            and conn.headers["content-type"] != "application/zip"
         ):
             wait_time = 10
             total_wait_time += wait_time
@@ -81,8 +81,8 @@ class Hydroshare(DoiProvider):
             )
             time.sleep(wait_time)
             conn = self.urlopen(bag_url)
-        if conn.getcode() != 200:
-            msg = "Failed to download bag. status code {}.\n".format(conn.getcode())
+        if conn.status_code != 200:
+            msg = "Failed to download bag. status code {}.\n".format(conn.status_code)
             yield msg
             raise ContentProviderException(msg)
         # Bag creation seems to need a small time buffer after it says it's ready.

--- a/tests/unit/contentproviders/test_hydroshare.py
+++ b/tests/unit/contentproviders/test_hydroshare.py
@@ -109,25 +109,11 @@ def hydroshare_archive(prefix="b8f6eae9d89241cf8b5904033460af61/data/contents"):
         yield zfile
 
 
-class MockInfo:
-    def __init__(self, content_type):
-        self.content_type = content_type
-
-    def get_content_type(self):
-        return self.content_type
-
-
 class MockResponse:
     def __init__(self, content_type, status_code):
-        self.content_type = content_type
         self.status_code = status_code
-        self.mock_info = MockInfo(self.content_type)
-
-    def getcode(self):
-        return self.status_code
-
-    def info(self):
-        return self.mock_info
+        self.headers = dict()
+        self.headers["content-type"] = content_type
 
 
 def test_fetch_bag():


### PR DESCRIPTION
The build process was broken by https://github.com/jupyterhub/repo2docker/pull/993, binderhub wasn't able to build hydroshare repos.