### PR TITLE
Add study participation notice to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,19 @@ For support questions please search or post to https://discourse.jupyter.org/c/b
 See the [contributing guide](CONTRIBUTING.md) for information on contributing to
 repo2docker.
 
+---
+
+Please note that this repository is participating in a study into sustainability
+of open source projects. Data will be gathered about this repository for
+approximately the next 12 months, starting from 2021-06-11.
+
+Data collected will include number of contributors, number of PRs, time taken to
+close/merge these PRs, and issues closed.
+
+For more information, please visit
+[our informational page](https://sustainable-open-science-and-software.github.io/) or download our [participant information sheet](https://sustainable-open-science-and-software.github.io/assets/PIS_sustainable_software.pdf).
+
+---
 
 ## Using repo2docker
 ### Prerequisites


### PR DESCRIPTION
This PR adds a notice to the readme informing users that the repo is participating in an open source sustainability study, see https://github.com/jupyterhub/team-compass/issues/417 for details