### PR TITLE
Hide `apt-get update` output

### DIFF
--- a/repo2docker/buildpacks/base.py
+++ b/repo2docker/buildpacks/base.py
@@ -18,7 +18,7 @@ FROM buildpack-deps:bionic
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Set up locales properly
-RUN apt-get -qq update && \
+RUN apt-get -qq update > /dev/null && \
     apt-get -qq install --yes --no-install-recommends locales > /dev/null && \
     apt-get -qq purge && \
     apt-get -qq clean && \
@@ -59,7 +59,7 @@ RUN wget --quiet -O - https://deb.nodesource.com/gpgkey/nodesource.gpg.key |  ap
 
 # Base package installs are not super interesting to users, so hide their outputs
 # If install fails for some reason, errors will still be printed
-RUN apt-get -qq update && \
+RUN apt-get -qq update > /dev/null && \
     apt-get -qq install --yes --no-install-recommends \
        {% for package in base_packages -%}
        {{ package }} \
@@ -70,7 +70,7 @@ RUN apt-get -qq update && \
     rm -rf /var/lib/apt/lists/*
 
 {% if packages -%}
-RUN apt-get -qq update && \
+RUN apt-get -qq update > /dev/null && \
     apt-get -qq install --yes \
        {% for package in packages -%}
        {{ package }} \
@@ -682,7 +682,7 @@ class BaseImage(BuildPack):
                     "root",
                     # This apt-get install is *not* quiet, since users explicitly asked for this
                     r"""
-                apt-get -qq update && \
+                apt-get -qq update > /dev/null && \
                 apt-get install --yes --no-install-recommends {} && \
                 apt-get -qq purge && \
                 apt-get -qq clean && \


### PR DESCRIPTION
`apt-get update` produces a lot of output that's mostly
irrelevant unless there is an error. This PR will suppress
stdout, but stderr will still show - so we can see errors
if they happen.
