### PR TITLE
Stop using deprecated add_stylesheet in sphinx

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -47,7 +47,7 @@ from recommonmark.transform import AutoStructify
 
 
 def setup(app):
-    app.add_stylesheet("custom.css")  # may also be a URL
+    app.add_css_file("custom.css")  # may also be a URL
     app.add_config_value(
         "recommonmark_config", {"auto_toc_tree_section": "Contents"}, True
     )


### PR DESCRIPTION
add_stylesheet has been deprecated for a while.

This should hopefully fix the CI failures in circleci

<!--

Our guide to getting a PR merged https://repo2docker.readthedocs.io/en/latest/contributing/contributing.html#guidelines-to-getting-a-pull-request-merged.

About to propose a big change? Read https://repo2docker.readthedocs.io/en/latest/contributing/contributing.html#process-for-making-a-contribution to maximise the chances of it getting merged quickly.

-->
