### PR TITLE
Pin doc requirements to avoid CI breakages

### DIFF
--- a/docs/doc-requirements.txt
+++ b/docs/doc-requirements.txt
@@ -1,6 +1,6 @@
 # Note that there is also a Pipfile for this project if you are updating this
 # file do not forget to update the Pipfile accordingly
-sphinx>=1.4, !=1.5.4
-recommonmark
-sphinxcontrib-autoprogram
-pydata-sphinx-theme
+sphinx==4.0.2
+recommonmark==0.7.1
+sphinxcontrib-autoprogram==0.1.7
+pydata-sphinx-theme==0.6.3


### PR DESCRIPTION
Follow-up to https://github.com/jupyterhub/repo2docker/pull/1050

This pins the versions of all doc dependencies, so we can rely on dependabot to check for problems with updates.

There's no dependabot.yml file in https://github.com/jupyterhub/repo2docker/tree/master/.github but it looks like dependabot has previously opened PRs in this repo: https://github.com/jupyterhub/repo2docker/pulls?q=is%3Apr+author%3Aapp%2Fdependabot+is%3Aclosed

so presumably it's been configured elsewhere?