### PR TITLE
Build ARM64 Docker images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,3 +32,66 @@ jobs:
         uses: pypa/gh-action-pypi-publish@master
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
+
+  publish-docker:
+    runs-on: ubuntu-20.04
+
+    services:
+      # So that we can test this in PRs/branches
+      local-registry:
+        image: registry:2
+        ports:
+          - 5000:5000
+
+    steps:
+      - name: Should we push this image to a public registry?
+        run: |
+          if [ "${{ startsWith(github.ref, 'refs/tags/') || (github.ref == 'refs/heads/master') }}" = "true" ]; then
+              # Empty => Docker Hub
+              echo "REGISTRY=" >> $GITHUB_ENV
+          else
+              echo "REGISTRY=localhost:5000/" >> $GITHUB_ENV
+          fi
+
+      # versioneer requires the full git history for non-tags
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      # Setup docker to build for multiple platforms, see:
+      # https://github.com/docker/build-push-action/tree/v2.4.0#usage
+      # https://github.com/docker/build-push-action/blob/v2.4.0/docs/advanced/multi-platform.md
+
+      - name: Set up QEMU (for docker buildx)
+        uses: docker/setup-qemu-action@25f0500ff22e406f7191a2a8ba8cda16901ca018
+
+      - name: Set up Docker Buildx (for multi-arch builds)
+        uses: docker/setup-buildx-action@2a4b53665e15ce7d7049afb11ff1f70ff1610609
+        with:
+          # Allows pushing to registry on localhost:5000
+          driver-opts: network=host
+
+      - name: Setup push rights to Docker Hub
+        if: env.REGISTRY != 'localhost:5000/'
+        run: |
+          docker login -u "${{ secrets.DOCKERHUB_USERNAME }}" -p "${{ secrets.DOCKERHUB_TOKEN }}"
+
+      # when building jupyter/repo2docker:master
+      # also push jupyter/repo2docker:1.2.3-3.abcd1234 (replace + with -)
+      - name: Get list of repo2docker docker tags
+        run: |
+          VERSION=$(python3 -c 'import versioneer; print(versioneer.get_version().replace("+", "-"))')
+          TAGS="${{ env.REGISTRY }}jupyter/repo2docker:$VERSION"
+          if [ "${{ github.ref }}" == "refs/heads/master" ]; then
+            TAGS="$TAGS,${{ env.REGISTRY }}jupyter/repo2docker:master"
+          fi
+          echo "TAGS=$TAGS"
+          echo "TAGS=$TAGS" >> $GITHUB_ENV
+
+      - name: Build and push repo2docker
+        uses: docker/build-push-action@e1b7f96249f2e4c8e4ac1519b9608c0d48944a1f
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ env.TAGS }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,7 @@ RUN apk add --no-cache git python3 python3-dev py-pip build-base
 
 # build wheels in first image
 ADD . /tmp/src
-# restore the hooks directory so that the repository isn't marked as dirty
-RUN cd /tmp/src && git clean -xfd && git checkout -- hooks && git status
+RUN cd /tmp/src && git clean -xfd && git status
 RUN mkdir /tmp/wheelhouse \
  && cd /tmp/wheelhouse \
  && pip3 install wheel \

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -1,3 +1,0 @@
-# Docker build hooks
-
-These define our [custom hooks for docker automated builds](https://docs.docker.com/docker-hub/builds/advanced/#custom-build-phase-hooks)

--- a/hooks/post_push
+++ b/hooks/post_push
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-# when building jupyter/repo2docker:master
-# also push jupyter/repo2docker:1.2.3-3.abcd1234 (replace + with -)
-version=$(docker run $DOCKER_REPO:$DOCKER_TAG jupyter-repo2docker --version | sed s@+@-@)
-VERSION_IMAGE="$DOCKER_REPO:$version"
-docker tag $DOCKER_REPO:$DOCKER_TAG "$VERSION_IMAGE"
-docker push "$VERSION_IMAGE"


### PR DESCRIPTION
We're doing it in JupyterHub and Z2JH, why not here too?

This is a modification of the [JupyterHub workflow](https://github.com/jupyterhub/jupyterhub/blob/c0b9250376a3c5919da8304b33c5124697996cec/.github/workflows/release.yml#L72-L145). The main difference is the Docker image tags are calculated using the method from the existing Docker Hub automated build hook:
https://github.com/jupyterhub/repo2docker/blob/eb7520901913d61e7745d136ce127142d5fa8506/hooks/post_push#L3-L6

Prerequisites:
- [ ] Disable automated Docker Hub build
- [ ] Add `secrets.DOCKERHUB_USERNAME` `secrets.DOCKERHUB_TOKEN` to push to Docker Hub
- [ ] Figure out how to freeze packages for arm64 (https://github.com/jupyterhub/repo2docker/pull/1024 makes it a lot easier)