### PR TITLE
Bump conda and mamba versions

### DIFF
--- a/repo2docker/buildpacks/conda/freeze.py
+++ b/repo2docker/buildpacks/conda/freeze.py
@@ -19,7 +19,7 @@ import sys
 from ruamel.yaml import YAML
 
 
-DOCKER_IMAGE = "condaforge/mambaforge:4.9.2-5"
+DOCKER_IMAGE = "condaforge/mambaforge:4.10.3-1"
 # set mamba and/or conda versions
 # if needed to differ from what's in the image
 MAMBA_VERSION = ""

--- a/repo2docker/buildpacks/conda/install-miniforge.bash
+++ b/repo2docker/buildpacks/conda/install-miniforge.bash
@@ -5,10 +5,10 @@ set -ex
 
 
 cd $(dirname $0)
-MINIFORGE_VERSION=4.9.2-2
-MAMBA_VERSION=0.7.4
+MINIFORGE_VERSION=4.10.3-1
+MAMBA_VERSION=0.14.1
 # SHA256 for installers can be obtained from https://github.com/conda-forge/miniforge/releases
-SHA256SUM="7a7bfaff87680298304a97ba69bcf92f66c810995a7155a2918b99fafb8ca1dc"
+SHA256SUM="72c623cc9ce300c5ad54e0b383e428b13e5c640e74529295ab61fbbfa1a8acaa"
 
 URL="https://github.com/conda-forge/miniforge/releases/download/${MINIFORGE_VERSION}/Mambaforge-${MINIFORGE_VERSION}-Linux-x86_64.sh"
 INSTALLER_PATH=/tmp/miniforge-installer.sh

--- a/tests/conda/binder-dir/verify
+++ b/tests/conda/binder-dir/verify
@@ -5,6 +5,6 @@ from subprocess import check_output
 assert sys.version_info[:2] == (3, 5), sys.version
 
 out = check_output(["conda", "--version"]).decode("utf8").strip()
-assert out == "conda 4.9.2", out
+assert out == "conda 4.10.3", out
 
 import numpy


### PR DESCRIPTION
Mamba has a much newer version, and miniforge went up by one minor release.