### PR TITLE
fix: add chardet, a not explicitly declared dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup(
     name="jupyter-repo2docker",
     version=versioneer.get_version(),
     install_requires=[
+        "chardet",
         "docker",
         "entrypoints",
         "escapism",


### PR DESCRIPTION
The `setup.py` file is missing the imported dependency [chardet](https://pypi.org/project/chardet/). This PR adds that dependency 

PR will fix issue #1063 