### PR TITLE
Workaround docker-py dependency's failure to import six

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,6 @@ RUN mkdir /tmp/wheelhouse \
  && cd /tmp/wheelhouse \
  && pip3 install wheel \
  && pip3 wheel --no-cache-dir /tmp/src \
- && rm /tmp/wheelhouse/six*.whl \
  && ls -l /tmp/wheelhouse
 
 FROM alpine:${ALPINE_VERSION}

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN mkdir /tmp/wheelhouse \
  && cd /tmp/wheelhouse \
  && pip3 install wheel \
  && pip3 wheel --no-cache-dir /tmp/src \
+ && rm /tmp/wheelhouse/six*.whl \
  && ls -l /tmp/wheelhouse
 
 FROM alpine:${ALPINE_VERSION}

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     version=versioneer.get_version(),
     install_requires=[
         "chardet",
-        "docker",
+        "docker!=5.0.0",
         "entrypoints",
         "escapism",
         "iso8601",
@@ -57,9 +57,6 @@ setup(
         "requests",
         "ruamel.yaml>=0.15",
         "semver",
-        # six installation is a workaround of https://github.com/docker/docker-py/pull/2844.
-        # When removing this, also remove the "rm /tmp/wheelhouse/six*.whl" line in ./Dockerfile
-        "six",
         "toml",
         "traitlets",
     ],

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,9 @@ setup(
         "requests",
         "ruamel.yaml>=0.15",
         "semver",
+        # six installation is a workaround of https://github.com/docker/docker-py/pull/2844.
+        # When removing this, also remove the "rm /tmp/wheelhouse/six*.whl" line in ./Dockerfile
+        "six",
         "toml",
         "traitlets",
     ],


### PR DESCRIPTION
`repo2docker` depends on `docker`, but `docker==5.0.0` is failing to import its dependency `six` and isn't getting patched because of a lack of maintainers it seems.

This is a PR similar to one we have done for `chartpress` as well (https://github.com/jupyterhub/chartpress/commit/8b486732f4ea518f65f4538dbb4e334f5e8aa5c6). The reason for repo2docker tests succeeds anyhow without this workaround is because six is available due to other reasons in the environment where tests run apparently.

PS: The Dockerfile was updated as installing a six wheel would fail as it would uninstall an existing six first but run into a failure doing so, so I adjusted the Dockerfile to not try to install a `six` wheel from the previous Dockerfile build step.

Closes #1039