### PR TITLE
Rename master branch to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # <a href="https://github.com/jupyterhub/repo2docker"><img src="https://raw.githubusercontent.com/jupyterhub/repo2docker/8731ecf0967cc5fde028c456f2b92be651ebbc18/docs/source/_static/images/repo2docker.png" height="48px" /> repo2docker</a>
 
-[![Deploy Status](https://travis-ci.org/jupyterhub/repo2docker.svg?branch=master)](https://travis-ci.org/jupyterhub/repo2docker)
 [![Build Status](https://github.com/jupyterhub/repo2docker/workflows/Continuous%20Integration/badge.svg)](https://github.com/jupyterhub/repo2docker/actions)
 [![Documentation Status](https://readthedocs.org/projects/repo2docker/badge/?version=latest)](http://repo2docker.readthedocs.io/en/latest/?badge=latest)
 [![Contribute](https://img.shields.io/badge/I_want_to_contribute!-grey?logo=jupyter)](https://repo2docker.readthedocs.io/en/latest/contributing/contributing.html)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -60,8 +60,8 @@ def setup(app):
 # source_suffix = ['.rst', '.md']
 source_suffix = [".rst", ".md"]
 
-# The master toctree document.
-master_doc = "index"
+# The root toctree document.
+root_doc = master_doc = "index"
 
 # General information about the project.
 project = "repo2docker"

--- a/docs/source/config_files.rst
+++ b/docs/source/config_files.rst
@@ -29,7 +29,7 @@ can be found on this page (and to the right).
 that lets you install any kind of package,
 including Python, R, and C/C++ packages.
 ``repo2docker`` does not use your ``environment.yml`` to create and activate a new conda environment.
-Rather, it updates a base conda environment `defined here <https://github.com/jupyterhub/repo2docker/blob/master/repo2docker/buildpacks/conda/environment.yml>`_ with the packages listed in your ``environment.yml``.
+Rather, it updates a base conda environment `defined here <https://github.com/jupyterhub/repo2docker/blob/HEAD/repo2docker/buildpacks/conda/environment.yml>`_ with the packages listed in your ``environment.yml``.
 This means that the environment will always have the same default name, not the name
 specified in your ``environment.yml``.
 

--- a/docs/source/config_files.rst
+++ b/docs/source/config_files.rst
@@ -37,7 +37,7 @@ specified in your ``environment.yml``.
 
    You can install files from pip in your ``environment.yml`` as well.
    For example, see the `binder-examples environment.yml
-   <https://github.com/binder-examples/python-conda_pip/blob/master/environment.yml>`_
+   <https://github.com/binder-examples/python-conda_pip/blob/HEAD/environment.yml>`_
    file.
 
 You can also specify which Python version to install in your built environment
@@ -73,7 +73,7 @@ both kinds.
 
 This specifies a list of Python packages that should be installed in your
 environment. Our
-`requirements.txt example <https://github.com/binder-examples/requirements/blob/master/requirements.txt>`_
+`requirements.txt example <https://github.com/binder-examples/requirements/blob/HEAD/requirements.txt>`_
 on GitHub shows a typical requirements file.
 
 
@@ -120,7 +120,7 @@ with ``REQUIRE`` and ``environment.yml``, visit
 This is used to install R libraries pinned to a specific snapshot on
 `MRAN <https://mran.microsoft.com/documents/rro/reproducibility>`_.
 To set the date of the snapshot add a runtime.txt_.
-For an example ``install.R`` file, visit our `example install.R file <https://github.com/binder-examples/r/blob/master/install.R>`_.
+For an example ``install.R`` file, visit our `example install.R file <https://github.com/binder-examples/r/blob/HEAD/install.R>`_.
 
 
 .. _apt.txt:
@@ -132,7 +132,7 @@ A list of Debian packages that should be installed. The base image used is usual
 version of Ubuntu.
 
 We use ``apt.txt``, for example, to install LaTeX in our
-`example apt.txt for LaTeX <https://github.com/binder-examples/latex/blob/master/apt.txt>`_.
+`example apt.txt for LaTeX <https://github.com/binder-examples/latex/blob/HEAD/apt.txt>`_.
 
 
 .. _DESCRIPTION:
@@ -162,7 +162,7 @@ You should include ``set -e`` or the equivalent at the start of the script to av
 
 An example use-case of ``postBuild`` file is JupyterLab's demo on mybinder.org.
 It uses a ``postBuild`` file in a folder called ``binder`` to `prepare
-their demo for binder <https://github.com/jupyterlab/jupyterlab-demo/blob/master/binder/postBuild>`_.
+their demo for binder <https://github.com/jupyterlab/jupyterlab-demo/blob/HEAD/binder/postBuild>`_.
 
 
 .. _start:
@@ -204,12 +204,12 @@ For these cases, we have a special file, ``runtime.txt``.
    ``runtime.txt`` will be ignored).
 
 Have ``python-x.y`` in ``runtime.txt`` to run the repository with Python version x.y.
-See our `Python2 example repository <https://github.com/binder-examples/python2_runtime/blob/master/runtime.txt>`_.
+See our `Python2 example repository <https://github.com/binder-examples/python2_runtime/blob/HEAD/runtime.txt>`_.
 
 Have ``r-<RVERSION>-<YYYY>-<MM>-<DD>`` in ``runtime.txt`` to run the repository with R version RVERSION and libraries from a YYYY-MM-DD snapshot of `MRAN <https://mran.microsoft.com/documents/rro/reproducibility>`_.
 RVERSION can be set to 3.4, 3.5, 3.6, or to patch releases for the 3.5 and 3.6 series.
 If you do not specify a version, the latest release will be used (currently R 3.6).
-See our `R example repository <https://github.com/binder-examples/r/blob/master/runtime.txt>`_.
+See our `R example repository <https://github.com/binder-examples/r/blob/HEAD/runtime.txt>`_.
 
 .. _default.nix:
 

--- a/docs/source/contributing/buildpack.md
+++ b/docs/source/contributing/buildpack.md
@@ -1,7 +1,7 @@
 # Add a new buildpack
 
 A new buildpack is needed when a new language or a new package manager should be
-supported. [Existing buildpacks](https://github.com/jupyterhub/repo2docker/tree/master/repo2docker/buildpacks)
+supported. [Existing buildpacks](https://github.com/jupyterhub/repo2docker/tree/HEAD/repo2docker/buildpacks)
 are a good model for how new buildpacks should be structured.
 See [the Buildpacks page](buildpacks) for more information about the
 structure of a buildpack.

--- a/docs/source/contributing/contentprovider.rst
+++ b/docs/source/contributing/contentprovider.rst
@@ -5,7 +5,7 @@ Add a new content provider
 Adding a new content provider allows repo2docker to grab repositories from new
 locations on the internet. To do so, you should take the following steps:
 
-#. Sub-class the `ContentProvider class <https://github.com/jupyterhub/repo2docker/blob/master/repo2docker/contentproviders/base.py#L17>`_.
+#. Sub-class the `ContentProvider class <https://github.com/jupyterhub/repo2docker/blob/HEAD/repo2docker/contentproviders/base.py#L17>`_.
    This will give you a skeleton class you can modify to support your new
    content provider.
 #. Implement a **detect()** method for the class. This takes an input

--- a/docs/source/contributing/contributing.md
+++ b/docs/source/contributing/contributing.md
@@ -64,8 +64,8 @@ Read the [next section](#guidelines-to-getting-a-pull-request-merged) for guidel
 6. Wait for a community member to merge your changes.
   Remember that **someone else must merge your pull request**.
   That goes for new contributors and long term maintainers alike.
-  Because `master` is continuously deployed to mybinder.org it is essential
-  that `master` is always in a deployable state.
+  Because `main` is continuously deployed to mybinder.org it is essential
+  that `main` is always in a deployable state.
 7. (optional) Deploy a new version of repo2docker to mybinder.org by [following these steps](http://mybinder-sre.readthedocs.io/en/latest/deployment/how.html)
 
 ## Guidelines to getting a Pull Request merged

--- a/docs/source/contributing/roadmap.md
+++ b/docs/source/contributing/roadmap.md
@@ -60,7 +60,7 @@ creating the environment in which a piece of software can be executed.
 
 The "Now" items are being actively worked on by the project:
 * reduce documentation typos and syntax errors
-* increase test coverage to 80% (see https://codecov.io/gh/jupyterhub/repo2docker/tree/master/repo2docker for low coverage files)
+* increase test coverage to 80% (see https://codecov.io/gh/jupyterhub/repo2docker/tree/main/repo2docker for low coverage files)
 * mounting repository contents in locations that is not `/home/jovyan`
 * investigate options for pinning repo2docker versions ([#490](https://github.com/jupyterhub/repo2docker/issues/490))
 

--- a/docs/source/contributing/tasks.md
+++ b/docs/source/contributing/tasks.md
@@ -52,8 +52,8 @@ To update one of the dependencies shared across all `repo2docker` builds, you
 must follow these steps (with more detailed information in the sections below):
 
 1. Make sure you have [Docker](https://www.docker.com/) running on your computer
-2. Bump the version numbers of the dependencies you want to update in the `conda` environment ([link](https://github.com/jupyterhub/repo2docker/blob/master/CONTRIBUTING.md#conda-dependencies))
-3. Make a pull request with your changes ([link](https://github.com/jupyterhub/repo2docker/blob/master/CONTRIBUTING.md#make-a-pull-request))
+2. Bump the version numbers of the dependencies you want to update in the `conda` environment ([link](https://github.com/jupyterhub/repo2docker/blob/HEAD/CONTRIBUTING.md#conda-dependencies))
+3. Make a pull request with your changes ([link](https://github.com/jupyterhub/repo2docker/blob/HEAD/CONTRIBUTING.md#make-a-pull-request))
 
 See the subsections below for more detailed instructions.
 

--- a/docs/source/contributing/tasks.md
+++ b/docs/source/contributing/tasks.md
@@ -115,7 +115,7 @@ test to prevent the bug from coming back/the feature breaking in the future.
 
 ## Creating a Release
 
-We make a release of whatever is on `master` every month. We use "calendar versioning".
+We make a release of whatever is on `main` every month. We use "calendar versioning".
 Monthly releases give users a predictable pattern for when releases are going to
 happen and prevents locking up improvements for fixes for long periods of time.
 
@@ -135,7 +135,7 @@ V=YYYY.MM.0; git tag -am "release $V" $V
 > If you need to make a second (or third) release in a month increment the
 > trailing 0 of the version to 1 (or 2).
 
-Then push this change up to the master repository
+Then push this change up to the main repository
 
 ```
 git push origin --tags

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -28,7 +28,7 @@ Repo2docker officially supports the following versions of Python
 - 2.7
 
 Additional versions may work, as long as the
-`base environment <https://github.com/jupyterhub/repo2docker/blob/master/repo2docker/buildpacks/conda/environment.yml>`_
+`base environment <https://github.com/jupyterhub/repo2docker/blob/HEAD/repo2docker/buildpacks/conda/environment.yml>`_
 can be installed for your version of Python.
 The most likely source of incompatibility is if one of the packages
 in the base environment is not packaged for your Python,

--- a/docs/source/howto/user_interface.rst
+++ b/docs/source/howto/user_interface.rst
@@ -30,7 +30,7 @@ For example, the following Binder URL will open the
 `pyTudes repository <https://github.com/norvig/pytudes>`_
 and begin a JupyterLab session in the ``ipynb`` folder:
 
-https://mybinder.org/v2/gh/norvig/pytudes/master?urlpath=lab/tree/ipynb
+https://mybinder.org/v2/gh/norvig/pytudes/HEAD?urlpath=lab/tree/ipynb
 
 The ``/tree/ipynb`` above is how JupyterLab directs you to a specific file
 or folder.
@@ -61,7 +61,7 @@ For example, the following Binder URL will open the
 `pyTudes repository <https://github.com/norvig/pytudes>`_
 and begin an nteract session in the ``ipynb`` folder:
 
-https://mybinder.org/v2/gh/norvig/pytudes/master?urlpath=nteract/tree/ipynb
+https://mybinder.org/v2/gh/norvig/pytudes/HEAD?urlpath=nteract/tree/ipynb
 
 The ``/tree/ipynb`` above is how nteract directs you to a specific file
 or folder.
@@ -83,7 +83,7 @@ RStudio will be accessible by appending ``/rstudio`` to the URL, like so:
 For example, the following Binder link will open an RStudio session in
 the `R demo repository <https://github.com/binder-examples/r>`_.
 
-http://mybinder.org/v2/gh/binder-examples/r/master?urlpath=rstudio
+http://mybinder.org/v2/gh/binder-examples/r/HEAD?urlpath=rstudio
 
 
 Shiny
@@ -106,7 +106,7 @@ a Shiny app.
 For example, the following Binder link will open a Shiny session in
 the `R demo repository <https://github.com/binder-examples/r>`_.
 
-http://mybinder.org/v2/gh/binder-examples/r/master?urlpath=shiny/bus-dashboard/
+http://mybinder.org/v2/gh/binder-examples/r/HEAD?urlpath=shiny/bus-dashboard/
 
 
 Stencila

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -19,7 +19,7 @@ to build images on demand.
 
 Please report `Bugs <https://github.com/jupyterhub/repo2docker/issues>`_,
 `ask questions <https://gitter.im/jupyterhub/binder>`_ or
-`contribute to the project <https://github.com/jupyterhub/repo2docker/blob/master/CONTRIBUTING.md>`_.
+`contribute to the project <https://github.com/jupyterhub/repo2docker/blob/HEAD/CONTRIBUTING.md>`_.
 
 .. toctree::
    :maxdepth: 2

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -19,7 +19,7 @@ The latest version of Docker, ``18.03``, successfully builds repositories from
 `binder-examples <https://github.com/binder-examples>`_.
 The `BinderHub <https://binderhub.readthedocs.io/>`_ helm chart uses version
 ``17.11.0-ce-dind``.  See the
-`helm chart <https://github.com/jupyterhub/binderhub/blob/master/helm-chart/binderhub/values.yaml#L167>`_
+`helm chart <https://github.com/jupyterhub/binderhub/blob/HEAD/helm-chart/binderhub/values.yaml#L167>`_
 for more details.
 
 Optional: Mercurial

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -48,7 +48,7 @@ We recommend installing ``repo2docker`` with the ``pip`` tool::
 
 for the latest release. To install the most recent code from the upstream repository, run::
 
-    python3 -m pip install https://github.com/jupyterhub/repo2docker/archive/master.zip
+    python3 -m pip install https://github.com/jupyterhub/repo2docker/archive/main.zip
 
 For information on using ``repo2docker``, see :ref:`usage`.
 

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -52,7 +52,7 @@ Pytudes_ repository::
 Building the image may take a few minutes.
 
 Pytudes_
-uses a `requirements.txt file <https://github.com/norvig/pytudes/blob/master/requirements.txt>`_
+uses a `requirements.txt file <https://github.com/norvig/pytudes/blob/HEAD/requirements.txt>`_
 to specify its Python environment. Because of this, ``repo2docker`` will use
 ``pip`` to install dependencies listed in this ``requirement.txt`` file, and
 these will be present in the generated Docker image. To learn more about

--- a/hooks/post_push
+++ b/hooks/post_push
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# when building jupyter/repo2docker:master
+# when building jupyter/repo2docker:main
 # also push jupyter/repo2docker:1.2.3-3.abcd1234 (replace + with -)
 version=$(docker run $DOCKER_REPO:$DOCKER_TAG jupyter-repo2docker --version | sed s@+@-@)
 VERSION_IMAGE="$DOCKER_REPO:$version"


### PR DESCRIPTION
Following process from https://github.com/jupyterhub/team-compass/issues/412

## Actions to take, in order:
- [x] approve this PR
- [x] rename the `master` branch to `main` in GitHub (this should automatically update all PRs)
- [x] merge this PR
- [ ] check the publish workflow publishes the expected outputs if relevant
- [ ] If readthedocs.org is used, set main as the default branch explicitly: admin -> advanced -> default branch

## `$ git grep master`
```
.github/workflows/release.yml:        uses: pypa/gh-action-pypi-publish@master
```
External action

```
docs/source/conf.py:# The master toctree document.
docs/source/conf.py:master_doc = "index"
docs/source/conf.py:        master_doc,
docs/source/conf.py:man_pages = [(master_doc, "repo2docker", "repo2docker Documentation", [author], 1)]
docs/source/conf.py:        master_doc,
```
Sphinx stuff

```
repo2docker/_version.py:        # "stabilization", as well as "HEAD" and "master".
```
Versioneer stuff

```
repo2docker/contentproviders/git.py:                if ref == "master":
repo2docker/contentproviders/git.py:                        "Failed to check out the 'master' branch. "
repo2docker/contentproviders/git.py:                        "Maybe the default branch is not named 'master' "
```
Explicit handling of `master`

```
repo2docker/utils.py:    https://github.com/docker/distribution/blob/master/reference/regexp.go
repo2docker/utils.py:        https://github.com/docker/distribution/blob/master/reference/regexp.go
```
External references

```
tests/conftest.py:    """Create a git repository with a git submodule in a non-master branch.
tests/conftest.py:    submodules are initialized properly when the master branch doesn't have
tests/external/reproductions.repos.yaml:  ref: origin/master
tests/external/reproductions.repos.yaml:  ref: master
tests/unit/contentproviders/test_git.py:    # indeed doesn't get any submodule, even though they are in master
tests/unit/test_clone_depth.py:    """Test a remote repository, with a refspec of 'master'"""
tests/unit/test_clone_depth.py:            ref="master",
tests/unit/test_clone_depth.py:    """Test a remote repository, with a refspec of the master commit hash"""
tests/unit/test_utils.py:            "--editable=git+https://github.com/popgensims/stdpopsim.git#egg=stdpopsim-master",
```
I've avoided changing anything under tests since it'll require code review to ensure we don't inadvertently remove a test case.

```
versioneer.py:(https://travis-ci.org/warner/python-versioneer.png?branch=master)
versioneer.py:  "master" and "slave" subprojects, each with their own `setup.py`,
versioneer.py:        # "stabilization", as well as "HEAD" and "master".
versioneer.py:        # "stabilization", as well as "HEAD" and "master".
```
Versioneer stuff
