### PR TITLE
GitHub workflow build and push to Docker hub

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,3 +32,66 @@ jobs:
         uses: pypa/gh-action-pypi-publish@master
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
+
+  publish-docker:
+    runs-on: ubuntu-20.04
+
+    services:
+      # So that we can test this in PRs/branches
+      local-registry:
+        image: registry:2
+        ports:
+          - 5000:5000
+
+    steps:
+      - name: Should we push this image to a public registry?
+        run: |
+          if [ "${{ startsWith(github.ref, 'refs/tags/') || (github.ref == 'refs/heads/master') }}" = "true" ]; then
+              # Empty => Docker Hub
+              echo "REGISTRY=" >> $GITHUB_ENV
+          else
+              echo "REGISTRY=localhost:5000/" >> $GITHUB_ENV
+          fi
+
+      # versioneer requires the full git history for non-tags
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      # Setup docker to build for multiple platforms, see:
+      # https://github.com/docker/build-push-action/tree/v2.4.0#usage
+      # https://github.com/docker/build-push-action/blob/v2.4.0/docs/advanced/multi-platform.md
+
+      - name: Set up QEMU (for docker buildx)
+        uses: docker/setup-qemu-action@25f0500ff22e406f7191a2a8ba8cda16901ca018
+
+      - name: Set up Docker Buildx (for multi-arch builds)
+        uses: docker/setup-buildx-action@2a4b53665e15ce7d7049afb11ff1f70ff1610609
+        with:
+          # Allows pushing to registry on localhost:5000
+          driver-opts: network=host
+
+      - name: Setup push rights to Docker Hub
+        if: env.REGISTRY != 'localhost:5000/'
+        run: |
+          docker login -u "${{ secrets.DOCKERHUB_USERNAME }}" -p "${{ secrets.DOCKERHUB_TOKEN }}"
+
+      # when building jupyter/repo2docker:master
+      # also push jupyter/repo2docker:1.2.3-3.abcd1234 (replace + with -)
+      - name: Get list of repo2docker docker tags
+        run: |
+          VERSION=$(python3 -c 'import versioneer; print(versioneer.get_version().replace("+", "-"))')
+          TAGS="${{ env.REGISTRY }}jupyter/repo2docker:$VERSION"
+          if [ "${{ github.ref }}" == "refs/heads/master" ]; then
+            TAGS="$TAGS,${{ env.REGISTRY }}jupyter/repo2docker:master"
+          fi
+          echo "TAGS=$TAGS"
+          echo "TAGS=$TAGS" >> $GITHUB_ENV
+
+      - name: Build and push repo2docker
+        uses: docker/build-push-action@e1b7f96249f2e4c8e4ac1519b9608c0d48944a1f
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ env.TAGS }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Create a release on pypi.org
+name: Publish
 
 on:
   push:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,8 +38,6 @@ jobs:
     env:
       DEFAULT_REGISTRY: quay.io
       IMAGE_NAME: jupyterhub/repo2docker
-    # Secrets are in a separate GitHub environment so only this job and branch has access
-    environment: quay.io
 
     services:
       # So that we can test this in PRs/branches

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,10 +50,11 @@ jobs:
       - name: Should we push this image to a public registry?
         run: |
           if [ "${{ startsWith(github.ref, 'refs/tags/') || (github.ref == 'refs/heads/main') }}" = "true" ]; then
-              echo "REGISTRY=$DEFAULT_REGISTRY" >> $GITHUB_ENV
+              REGISTRY=$DEFAULT_REGISTRY
           else
-              echo "REGISTRY=localhost:5000" >> $GITHUB_ENV
+              REGISTRY=localhost:5000
           fi
+          echo "REGISTRY=$REGISTRY" >> $GITHUB_ENV
           echo "Publishing to $REGISTRY"
 
       # versioneer requires the full git history for non-tags

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
     steps:
       - name: Should we push this image to a public registry?
         run: |
-          if [ "${{ startsWith(github.ref, 'refs/tags/') || (github.ref == 'refs/heads/master') }}" = "true" ]; then
+          if [ "${{ startsWith(github.ref, 'refs/tags/') || (github.ref == 'refs/heads/main') }}" = "true" ]; then
               # Empty => Docker Hub
               echo "REGISTRY=" >> $GITHUB_ENV
           else
@@ -82,8 +82,8 @@ jobs:
         run: |
           VERSION=$(python3 -c 'import versioneer; print(versioneer.get_version().replace("+", "-"))')
           TAGS="${{ env.REGISTRY }}jupyter/repo2docker:$VERSION"
-          if [ "${{ github.ref }}" == "refs/heads/master" ]; then
-            TAGS="$TAGS,${{ env.REGISTRY }}jupyter/repo2docker:master"
+          if [ "${{ github.ref }}" == "refs/heads/main" ]; then
+            TAGS="$TAGS,${{ env.REGISTRY }}jupyter/repo2docker:main"
           fi
           echo "TAGS=$TAGS"
           echo "TAGS=$TAGS" >> $GITHUB_ENV

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,11 @@ jobs:
 
   publish-docker:
     runs-on: ubuntu-20.04
+    env:
+      DEFAULT_REGISTRY: quay.io
+      IMAGE_NAME: jupyterhub/repo2docker
+    # Secrets are in a separate GitHub environment so only this job and branch has access
+    environment: quay.io
 
     services:
       # So that we can test this in PRs/branches
@@ -47,11 +52,11 @@ jobs:
       - name: Should we push this image to a public registry?
         run: |
           if [ "${{ startsWith(github.ref, 'refs/tags/') || (github.ref == 'refs/heads/main') }}" = "true" ]; then
-              # Empty => Docker Hub
-              echo "REGISTRY=" >> $GITHUB_ENV
+              echo "REGISTRY=$DEFAULT_REGISTRY" >> $GITHUB_ENV
           else
-              echo "REGISTRY=localhost:5000/" >> $GITHUB_ENV
+              echo "REGISTRY=localhost:5000" >> $GITHUB_ENV
           fi
+          echo "Publishing to $REGISTRY"
 
       # versioneer requires the full git history for non-tags
       - uses: actions/checkout@v2
@@ -72,18 +77,18 @@ jobs:
           driver-opts: network=host
 
       - name: Setup push rights to Docker Hub
-        if: env.REGISTRY != 'localhost:5000/'
+        if: env.REGISTRY != 'localhost:5000'
         run: |
-          docker login -u "${{ secrets.DOCKERHUB_USERNAME }}" -p "${{ secrets.DOCKERHUB_TOKEN }}"
+          docker login -u "${{ secrets.DOCKER_REGISTRY_USERNAME }}" -p "${{ secrets.DOCKER_REGISTRY_TOKEN }}" "${{ env.REGISTRY }}"
 
       # when building jupyter/repo2docker:master
       # also push jupyter/repo2docker:1.2.3-3.abcd1234 (replace + with -)
       - name: Get list of repo2docker docker tags
         run: |
           VERSION=$(python3 -c 'import versioneer; print(versioneer.get_version().replace("+", "-"))')
-          TAGS="${{ env.REGISTRY }}jupyter/repo2docker:$VERSION"
+          TAGS="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:$VERSION"
           if [ "${{ github.ref }}" == "refs/heads/main" ]; then
-            TAGS="$TAGS,${{ env.REGISTRY }}jupyter/repo2docker:main"
+            TAGS="$TAGS,${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:main"
           fi
           echo "TAGS=$TAGS"
           echo "TAGS=$TAGS" >> $GITHUB_ENV

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,6 +92,6 @@ jobs:
         uses: docker/build-push-action@e1b7f96249f2e4c8e4ac1519b9608c0d48944a1f
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
           tags: ${{ env.TAGS }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,7 @@ RUN apk add --no-cache git python3 python3-dev py-pip build-base
 
 # build wheels in first image
 ADD . /tmp/src
-# restore the hooks directory so that the repository isn't marked as dirty
-RUN cd /tmp/src && git clean -xfd && git checkout -- hooks && git status
+RUN cd /tmp/src && git clean -xfd && git status
 RUN mkdir /tmp/wheelhouse \
  && cd /tmp/wheelhouse \
  && pip3 install wheel \

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Build Status](https://github.com/jupyterhub/repo2docker/workflows/Continuous%20Integration/badge.svg)](https://github.com/jupyterhub/repo2docker/actions)
 [![Documentation Status](https://readthedocs.org/projects/repo2docker/badge/?version=latest)](http://repo2docker.readthedocs.io/en/latest/?badge=latest)
 [![Contribute](https://img.shields.io/badge/I_want_to_contribute!-grey?logo=jupyter)](https://repo2docker.readthedocs.io/en/latest/contributing/contributing.html)
+[![Docker Repository on Quay](https://quay.io/repository/jupyterhub/repo2docker/status "Docker Repository on Quay")](https://quay.io/repository/jupyterhub/repo2docker)
 
 `repo2docker` fetches a git repository and builds a container image based on
 the configuration files found in the repository.
@@ -95,3 +96,8 @@ files that ``repo2docker`` can use, see the
 
 The philosophy of repo2docker is inspired by
 [Heroku Build Packs](https://devcenter.heroku.com/articles/buildpacks).
+
+
+## Docker Image
+
+Repo2Docker can be run inside a Docker container if access to the Docker Daemon is provided, for example see [BinderHub](https://github.com/jupyterhub/binderhub). Docker images are [published to quay.io](https://quay.io/repository/jupyterhub/repo2docker). The old [Docker Hub image](https://hub.docker.com/r/jupyter/repo2docker) is no longer supported.

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -1,3 +1,0 @@
-# Docker build hooks
-
-These define our [custom hooks for docker automated builds](https://docs.docker.com/docker-hub/builds/advanced/#custom-build-phase-hooks)

--- a/hooks/post_push
+++ b/hooks/post_push
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-# when building jupyter/repo2docker:main
-# also push jupyter/repo2docker:1.2.3-3.abcd1234 (replace + with -)
-version=$(docker run $DOCKER_REPO:$DOCKER_TAG jupyter-repo2docker --version | sed s@+@-@)
-VERSION_IMAGE="$DOCKER_REPO:$version"
-docker tag $DOCKER_REPO:$DOCKER_TAG "$VERSION_IMAGE"
-docker push "$VERSION_IMAGE"


### PR DESCRIPTION
The `jupyter/repo2docker` Docker Hub image [hasn't been updated for 20 days (last tag is 16 July 2021)](https://hub.docker.com/r/jupyter/repo2docker/tags?page=1&ordering=last_updated).

[Two PRs have been merged](https://github.com/jupyterhub/repo2docker/pulls?q=is%3Apr+merged%3A%3E2021-07-16+) since that last build and those should've triggered a new Docker image.

Automated Docker Hub builds were meant to be [discontinued from 18 June](https://www.docker.com/blog/changes-to-docker-hub-autobuilds/) which is before the last build, but perhaps they kept going for a bit longer?

This PR is a copy of https://github.com/jupyterhub/repo2docker/pull/1055 but for amd64 only.
Since this is building for the native architecture there should be no time penalty in using docker buildx.

Required:
- [x] Add secrets for publishing to [`quay.io/jupyterhub/repo2docker`](https://quay.io/repository/jupyterhub/repo2docker?namespace=jupyterhub): `secrets.DOCKER_REGISTRY_USERNAME` `secrets.DOCKER_REGISTRY_TOKEN`