### PR TITLE
Fix Docker build (again)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,6 @@ RUN mkdir /tmp/wheelhouse \
  && cd /tmp/wheelhouse \
  && pip3 install wheel \
  && pip3 wheel --no-cache-dir /tmp/src \
- && rm /tmp/wheelhouse/six*.whl \
  && ls -l /tmp/wheelhouse
 
 FROM alpine:${ALPINE_VERSION}


### PR DESCRIPTION
The Docker build has broken (again): https://github.com/jupyterhub/repo2docker/runs/3506339228
```
#12 25.59 rm: can't remove '/tmp/wheelhouse/six*.whl': No such file or directory
#12 ERROR: executor failed running [/bin/sh -c mkdir /tmp/wheelhouse  && cd /tmp/wheelhouse  && pip3 install wheel  && pip3 wheel --no-cache-dir /tmp/src  && rm /tmp/wheelhouse/six*.whl  && ls -l /tmp/wheelhouse]: exit code: 1
```

This reverts commit https://github.com/jupyterhub/repo2docker/pull/1066/commits/f3906be35b9af1c1fef70864c90c76bcfe4d8004 from https://github.com/jupyterhub/repo2docker/pull/1066