### PR TITLE
Add `--gpus` flag and config to start built container with nvidia Driver.Capabilities

### DIFF
--- a/repo2docker/__main__.py
+++ b/repo2docker/__main__.py
@@ -219,6 +219,13 @@ def get_argparser():
 
     argparser.add_argument("--engine", help="Name of the container engine")
 
+    argparser.add_argument(
+        "--gpus",
+        dest="gpus",
+        action="store_true",
+        help="Expose the GPU device(s) to the containers",
+    )
+
     return argparser
 
 
@@ -280,6 +287,8 @@ def make_r2d(argv=None):
         # Can't push nor run if we aren't building
         args.run = False
         args.push = False
+
+    r2d.gpus = args.gpus
 
     r2d.run = args.run
     r2d.push = args.push

--- a/repo2docker/app.py
+++ b/repo2docker/app.py
@@ -381,6 +381,14 @@ class Repo2Docker(Application):
         config=True,
     )
 
+    gpus = Bool(
+        False,
+        help="""
+        Expose GPU device(s) when running a container
+        """,
+        config=False,
+    )
+
     engine = Unicode(
         "docker",
         config=True,
@@ -606,12 +614,33 @@ class Repo2Docker(Application):
                     "mode": "rw",
                 }
 
+        if self.gpus:
+            device_requests = [
+                {
+                    "Driver": "nvidia",
+                    "Capabilities": [
+                        ["gpu"],
+                        ["nvidia"],
+                        ["compute"],
+                        ["compat32"],
+                        ["graphics"],
+                        ["utility"],
+                        ["video"],
+                        ["display"],
+                    ],
+                    "Count": -1,  # enable all gpus
+                }
+            ]
+        else:
+            device_requests = []
+
         run_kwargs = dict(
             publish_all_ports=self.all_ports,
             ports=ports,
             command=run_cmd,
             volumes=container_volumes,
             environment=self.environment,
+            device_requests=device_requests,
         )
 
         run_kwargs.update(self.extra_run_kwargs)


### PR DESCRIPTION
Description
---

Add a `--gpus` CLI flag to enable gpu support when running a container from the CLI
Add a `gpus`  config on the app to store CLI value, default it to `False` to preserve current behavior
Pass a device request for gpu to the engine API

This assumes that the host is well configured as stated in [docker documentation](https://docs.docker.com/config/containers/resource_constraints/#gpu): both NVIDIA drivers and container runtime have to be installed.

Now, running `repo2docker --gpus <some-repo>` makes GPU(s) accessible from the container:

```
adrien@71ab26d163ff:~$ nvidia-smi
Tue Sep  7 10:00:55 2021       
+-----------------------------------------------------------------------------+
| NVIDIA-SMI 470.57.02    Driver Version: 470.57.02    CUDA Version: 11.4     |
(...)
+-----------------------------------------------------------------------------+
```
<!--

Our guide to getting a PR merged https://repo2docker.readthedocs.io/en/latest/contributing/contributing.html#guidelines-to-getting-a-pull-request-merged.

About to propose a big change? Read https://repo2docker.readthedocs.io/en/latest/contributing/contributing.html#process-for-making-a-contribution to maximise the chances of it getting merged quickly.

-->
