### PR TITLE
Set labels when building image from Dockerfile

### DIFF
--- a/repo2docker/__main__.py
+++ b/repo2docker/__main__.py
@@ -204,6 +204,14 @@ def get_argparser():
 
     argparser.add_argument("--appendix", type=str, help=Repo2Docker.appendix.help)
 
+    argparser.add_argument(
+        "--label",
+        dest="labels",
+        action="append",
+        help="Extra label to set on the image, in form name=value",
+        default=[],
+    )
+
     argparser.add_argument("--subdir", type=str, help=Repo2Docker.subdir.help)
 
     argparser.add_argument(
@@ -245,6 +253,13 @@ def make_r2d(argv=None):
     r2d.load_config_file(args.config)
     if args.appendix:
         r2d.appendix = args.appendix
+
+    for l in args.labels:
+        if "=" in l:
+            key, val = l.split("=", 1)
+            r2d.labels[key] = val
+        else:
+            r2d.labels[l] = ""
 
     r2d.repo = args.repo
     r2d.ref = args.ref

--- a/repo2docker/app.py
+++ b/repo2docker/app.py
@@ -237,6 +237,17 @@ class Repo2Docker(Application):
         """,
     )
 
+    labels = Dict(
+        {},
+        help="""
+        Extra labels to set on the final image.
+
+        Each Label is a key-value pair, with the key being the name of the label
+        and the value its value.
+        """,
+        config=True,
+    )
+
     json_logs = Bool(
         False,
         help="""
@@ -746,6 +757,8 @@ class Repo2Docker(Application):
                 repo_label = "local" if os.path.isdir(self.repo) else self.repo
                 picked_buildpack.labels["repo2docker.repo"] = repo_label
                 picked_buildpack.labels["repo2docker.ref"] = self.ref
+
+                picked_buildpack.labels.update(self.labels)
 
                 if self.dry_run:
                     print(picked_buildpack.render())

--- a/repo2docker/buildpacks/docker.py
+++ b/repo2docker/buildpacks/docker.py
@@ -52,6 +52,7 @@ class DockerBuildPack(BuildPack):
             buildargs=build_args,
             container_limits=limits,
             cache_from=cache_from,
+            labels=self.get_labels(),
         )
 
         build_kwargs.update(extra_build_kwargs)

--- a/repo2docker/docker.py
+++ b/repo2docker/docker.py
@@ -73,6 +73,7 @@ class DockerEngine(ContainerEngine):
         dockerfile="",
         fileobj=None,
         path="",
+        labels=None,
         **kwargs,
     ):
         return self._apiclient.build(
@@ -87,6 +88,7 @@ class DockerEngine(ContainerEngine):
             dockerfile=dockerfile,
             fileobj=fileobj,
             path=path,
+            labels=labels,
             **kwargs,
         )
 

--- a/repo2docker/engine.py
+++ b/repo2docker/engine.py
@@ -176,6 +176,7 @@ class ContainerEngine(LoggingConfigurable):
         dockerfile="",
         fileobj=None,
         path="",
+        labels=None,
         **kwargs,
     ):
         """
@@ -204,6 +205,8 @@ class ContainerEngine(LoggingConfigurable):
             A tar file-like object containing the build context
         path : str
             path to the Dockerfile
+        labels : dict
+            Dictionary of labels to set on the image
 
         Returns
         -------


### PR DESCRIPTION
We'd like to build our own custom images based on our own Docker Base-Images.
It works mostly fine, but the one big issue I ran into is that our Jupyter Hub does not show the images in its UI after successfully building them.

This is due to the labels it set on the command line not actually making it into the image. Adding them is easily achieved by adding this single line.

I also noticed that tljh makes use of an appendix to set some more stuff. So I extended this PR to have support for it as well.
For appendices to work, I needed to modify the Dockerfile on the fly, so I added that to the render method of the Docker BuildPack.
While making the build method based on that, I eventually realized that I had effectively re-implemented the base classes build method, with next to no differences.
And sure enough, just removing the build method entirely works like a charm.

This in turn meant that the label change had to move to the base class as well, where it could work in the exact same way, while simplifying the embedded Dockerfile a bit.
