### PR TITLE
Add command line option to pass extra build args

### DIFF
--- a/repo2docker/__main__.py
+++ b/repo2docker/__main__.py
@@ -263,11 +263,8 @@ def make_r2d(argv=None):
         r2d.appendix = args.appendix
 
     for l in args.labels:
-        if "=" in l:
-            key, val = l.split("=", 1)
-            r2d.labels[key] = val
-        else:
-            r2d.labels[l] = ""
+        key, _, val = l.partition("=")
+        r2d.labels[key] = val
 
     for a in args.build_args:
         key, _, val = a.partition("=")

--- a/repo2docker/__main__.py
+++ b/repo2docker/__main__.py
@@ -212,6 +212,14 @@ def get_argparser():
         default=[],
     )
 
+    argparser.add_argument(
+        "--build-arg",
+        dest="build_args",
+        action="append",
+        help="Extra build arg to pass to the build process, in form name=value",
+        default=[],
+    )
+
     argparser.add_argument("--subdir", type=str, help=Repo2Docker.subdir.help)
 
     argparser.add_argument(
@@ -260,6 +268,10 @@ def make_r2d(argv=None):
             r2d.labels[key] = val
         else:
             r2d.labels[l] = ""
+
+    for a in args.build_args:
+        key, _, val = a.partition("=")
+        r2d.extra_build_args[key] = val
 
     r2d.repo = args.repo
     r2d.ref = args.ref

--- a/repo2docker/app.py
+++ b/repo2docker/app.py
@@ -248,6 +248,15 @@ class Repo2Docker(Application):
         config=True,
     )
 
+    extra_build_args = Dict(
+        {},
+        help="""
+        Extra build args to pass to the image build process.
+        This is pretty much only useful for custom Dockerfile based builds.
+        """,
+        config=True,
+    )
+
     json_logs = Bool(
         False,
         help="""
@@ -777,6 +786,8 @@ class Repo2Docker(Application):
                     }
                     if self.target_repo_dir:
                         build_args["REPO_DIR"] = self.target_repo_dir
+                    build_args.update(self.extra_build_args)
+
                     self.log.info(
                         "Using %s builder\n",
                         bp.__class__.__name__,


### PR DESCRIPTION
This is effectively the second part of https://github.com/jupyterhub/repo2docker/pull/1097

Instead of allowing an appendix for custom Dockerfiles, this adds the ability to pass arbitrary build args to the build process, which is much cleaner and more predictable than appending lines to the Dockerfile.

For the normal buildpacks this does generally nothing, since they don't expect any buildargs you can't already set via other switches, but for custom Dockerfiles it adds a range of new possibilities.