### PR TITLE
Quieter R builds

### DIFF
--- a/repo2docker/buildpacks/_r_base.py
+++ b/repo2docker/buildpacks/_r_base.py
@@ -29,8 +29,8 @@ def rstudio_base_scripts():
             r"""
                 curl --silent --location --fail {rstudio_url} > /tmp/rstudio.deb && \
                 echo '{rstudio_checksum} /tmp/rstudio.deb' | md5sum -c - && \
-                apt-get update && \
-                apt install -y /tmp/rstudio.deb && \
+                apt-get update > /dev/null && \
+                apt install -y /tmp/rstudio.deb  > /dev/null && \
                 rm /tmp/rstudio.deb && \
                 apt-get -qq purge && \
                 apt-get -qq clean && \
@@ -45,7 +45,7 @@ def rstudio_base_scripts():
             r"""
                 curl --silent --location --fail {url} > {deb} && \
                 echo '{checksum} {deb}' | md5sum -c - && \
-                dpkg -i {deb} && \
+                dpkg -i {deb} > /dev/null && \
                 rm {deb}
                 """.format(
                 url=SHINY_URL, checksum=SHINY_CHECKSUM, deb="/tmp/shiny.deb"

--- a/repo2docker/buildpacks/r.py
+++ b/repo2docker/buildpacks/r.py
@@ -258,11 +258,11 @@ class RBuildPack(PythonBuildPack):
                 (
                     "root",
                     r"""
-                    apt-get update && \
+                    apt-get update > /dev/null && \
                     apt-get install --yes r-base={R_version} \
                          r-base-dev={R_version} \
                          r-recommended={R_version} \
-                         libclang-dev && \
+                         libclang-dev > /dev/null && \
                     apt-get -qq purge && \
                     apt-get -qq clean && \
                     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
We redirect stdout (not stderr) of apt-get update and install
in most other places (check out base.py) to not clutter the
output
