### PR TITLE
Bump default R version to 4.1

### DIFF
--- a/repo2docker/buildpacks/r.py
+++ b/repo2docker/buildpacks/r.py
@@ -80,7 +80,7 @@ class RBuildPack(PythonBuildPack):
             "4.1": "4.1.2-1.1804.0",
         }
         # the default if nothing is specified
-        r_version = "3.6"
+        r_version = "4.1"
 
         if not hasattr(self, "_r_version"):
             parts = self.runtime.split("-")

--- a/tests/r/simple/verify
+++ b/tests/r/simple/verify
@@ -1,2 +1,7 @@
 #!/usr/bin/env Rscript
 library('ggplot2')
+
+# Fail if version is not 4.1
+if (!(version$major == "4" && as.double(version$minor) >= 1 && as.double(version$minor) < 2)) {
+  quit("yes", 1)
+}

--- a/tests/unit/test_r.py
+++ b/tests/unit/test_r.py
@@ -22,7 +22,7 @@ def test_unsupported_version(tmpdir):
 
 
 @pytest.mark.parametrize(
-    "runtime_version, expected", [("", "3.6"), ("3.6", "3.6"), ("3.5.1", "3.5")]
+    "runtime_version, expected", [("", "4.1"), ("3.6", "3.6"), ("3.5.1", "3.5")]
 )
 def test_version_specification(tmpdir, runtime_version, expected):
     tmpdir.chdir()


### PR DESCRIPTION
3.6 is almost 4 years old now.

Related to https://github.com/jupyterhub/repo2docker/pull/1104 which
brings in a lot of other R improvements.