### PR TITLE
Revert "Bump default R version to 4.1"

### DIFF
--- a/repo2docker/buildpacks/r.py
+++ b/repo2docker/buildpacks/r.py
@@ -81,7 +81,7 @@ class RBuildPack(PythonBuildPack):
             "4.1": "4.1.2-1.1804.0",
         }
         # the default if nothing is specified
-        r_version = "4.1"
+        r_version = "3.6"
 
         if not hasattr(self, "_r_version"):
             parts = self.runtime.split("-")

--- a/tests/r/simple/verify
+++ b/tests/r/simple/verify
@@ -1,7 +1,2 @@
 #!/usr/bin/env Rscript
 library('ggplot2')
-
-# Fail if version is not 4.1
-if (!(version$major == "4" && as.double(version$minor) >= 1 && as.double(version$minor) < 2)) {
-  quit("yes", 1)
-}

--- a/tests/unit/test_r.py
+++ b/tests/unit/test_r.py
@@ -22,7 +22,7 @@ def test_unsupported_version(tmpdir):
 
 
 @pytest.mark.parametrize(
-    "runtime_version, expected", [("", "4.1"), ("3.6", "3.6"), ("3.5.1", "3.5")]
+    "runtime_version, expected", [("", "3.6"), ("3.6", "3.6"), ("3.5.1", "3.5")]
 )
 def test_version_specification(tmpdir, runtime_version, expected):
     tmpdir.chdir()


### PR DESCRIPTION
Reverts jupyterhub/repo2docker#1107 as the tests need to be updated:
https://github.com/jupyterhub/repo2docker/issues/1109