### PR TITLE
Say 'apt repository' rather than PPA

### DIFF
--- a/repo2docker/buildpacks/r.py
+++ b/repo2docker/buildpacks/r.py
@@ -177,7 +177,7 @@ class RBuildPack(PythonBuildPack):
             "lsb-release",
         ]
         # For R 3.4 we use the default Ubuntu package, for other versions we
-        # install from a different PPA
+        # install from a different apt repository
         if V(self.r_version) < V("3.5"):
             packages.append("r-base")
             packages.append("r-base-dev")

--- a/tests/unit/test_r.py
+++ b/tests/unit/test_r.py
@@ -117,7 +117,7 @@ def test_install_from_base(tmpdir):
     assert "r-base" in r.get_packages()
 
 
-def test_install_from_ppa(tmpdir):
+def test_install_from_cran_apt_repo(tmpdir):
     # check that for R>3.4 we don't install r-base from Ubuntu
     tmpdir.chdir()
 
@@ -128,7 +128,7 @@ def test_install_from_ppa(tmpdir):
     assert "r-base" not in r.get_packages()
 
 
-def test_custom_ppa(tmpdir):
+def test_custom_cran_apt_repo(tmpdir):
     tmpdir.chdir()
 
     with open("runtime.txt", "w") as f:
@@ -138,12 +138,12 @@ def test_custom_ppa(tmpdir):
 
     scripts = r.get_build_scripts()
 
-    # check that at least one of the build scripts adds this new PPA
+    # check that at least one of the build scripts adds this new apt repository
     for user, script in scripts:
         if "https://cloud.r-project.org/bin/linux/ubuntu bionic-cran35/" in script:
             break
     else:
-        assert False, "Should have added a new PPA"
+        assert False, "Should have added a new apt repository"
 
     # check that we install the right package
     for user, script in scripts:


### PR DESCRIPTION
PPA is a specific kind of apt repository, hosted on
launchpad.net. We use https://cran.r-project.org/bin/linux/ubuntu/,
which is just a regular apt repository. The PPA terminology
always confused me, so this just clears that up
