### PR TITLE
Only get R itself (r-base-core) from apt, not CRAN packages

### DIFF
--- a/repo2docker/buildpacks/_r_base.py
+++ b/repo2docker/buildpacks/_r_base.py
@@ -31,6 +31,9 @@ def rstudio_base_scripts(r_version):
     return [
         (
             "root",
+            # we should have --no-install-recommends on all our apt-get install commands,
+            # but here it's important because these recommend r-base,
+            # which will upgrade the installed version of R, undoing our pinned version
             r"""
             curl --silent --location --fail {rstudio_url} > /tmp/rstudio.deb && \
             curl --silent --location --fail {shiny_server_url} > /tmp/shiny.deb && \

--- a/repo2docker/buildpacks/_r_base.py
+++ b/repo2docker/buildpacks/_r_base.py
@@ -37,7 +37,7 @@ def rstudio_base_scripts(r_version):
             echo '{rstudio_sha256sum} /tmp/rstudio.deb' | sha256sum -c - && \
             echo '{shiny_sha256sum} /tmp/shiny.deb' | sha256sum -c - && \
             apt-get update > /dev/null && \
-            apt install -y /tmp/rstudio.deb /tmp/shiny.deb > /dev/null && \
+            apt install -y --no-install-recommends /tmp/rstudio.deb /tmp/shiny.deb && \
             rm /tmp/rstudio.deb && \
             apt-get -qq purge && \
             apt-get -qq clean && \

--- a/repo2docker/buildpacks/r.py
+++ b/repo2docker/buildpacks/r.py
@@ -292,6 +292,9 @@ class RBuildPack(PythonBuildPack):
             ),
             (
                 "root",
+                # we should have --no-install-recommends on all our apt-get install commands,
+                # but here it's important because it will pull in CRAN packages
+                # via r-recommends, which is only guaranteed to be compatible with the latest r-base-core
                 r"""
                 apt-get update > /dev/null && \
                 apt-get install --yes --no-install-recommends \

--- a/repo2docker/buildpacks/r.py
+++ b/repo2docker/buildpacks/r.py
@@ -38,8 +38,9 @@ class RBuildPack(PythonBuildPack):
 
     - are needed by a specific tool
 
-    The `r-base` package from Ubuntu apt repositories is used to install
-    R itself, rather than any of the methods from https://cran.r-project.org/.
+    The `r-base-core` package from Ubuntu or "Ubuntu packages for R"
+    apt repositories is used to install R itself,
+    rather than any of the methods from https://cran.r-project.org/.
 
     The `r-base-dev` package is installed as advised in RStudio instructions.
     """
@@ -293,9 +294,9 @@ class RBuildPack(PythonBuildPack):
                 "root",
                 r"""
                 apt-get update > /dev/null && \
-                apt-get install --yes r-base={R_version} r-base-core={R_version} \
+                apt-get install --yes --no-install-recommends \
+                        r-base-core={R_version} \
                         r-base-dev={R_version} \
-                        r-recommended={R_version} \
                         libclang-dev \
                         libzmq3-dev > /dev/null && \
                 apt-get -qq purge && \

--- a/tests/unit/test_r.py
+++ b/tests/unit/test_r.py
@@ -147,7 +147,7 @@ def test_custom_cran_apt_repo(tmpdir):
 
     # check that we install the right package
     for user, script in scripts:
-        if "r-base=3.5" in script:
+        if "r-base-core=3.5" in script:
             break
     else:
         assert False, "Should have installed base R"


### PR DESCRIPTION
r-recommended is a collection of common CRAN packages, which cause conflicts when trying to install older R because "Ubuntu packages for R" only support installing packages with the "latest stable R", not pinning older versions, and apt doesn't seem to have a real solver. This should be okay for us, as long as we only get R itself from apt, and not any of the CRAN packages, which can be retrieved from a regular CRAN install.

The reason I think this will be relatively safe, despite "Ubuntu for R" packages not supporting old builds of R is that `r-base-core` and `r-base-dev` do not have any dependencies on any other packages from the Ubuntu for R repo - all of their dependencies are from Ubuntu itself (Check the output of `apt-get install`). The "only latest stable" issue and conflicts we are seeing in #1116 should only come up with combinations of packages from the "Ubuntu for R" repo (in our current situation, r-cran-mass and a couple others have been updated to be incompatible with r-base-core=4.0.5). But if only the two pinned packages are coming from the repo, I _think_ the issue shouldn't come up again.

This _will_ break any repos where it is assumed that these recommended packages are present and a regular dependency on them is not specified. I don't know how likely that is, but the fix is straightforward - express a dependency on the CRAN packages you use.

closes #1116 

<details>
<summary>More info on the package diffs and dependencies</summary>

`apt-cache depends r-recommended` gives:

```
r-recommended
  Depends: r-base-core
  Depends: r-cran-boot
  Depends: r-cran-cluster
  Depends: r-cran-foreign
  Depends: r-cran-kernsmooth
  Depends: r-cran-lattice
  Depends: r-cran-mgcv
  Depends: r-cran-nlme
  Depends: r-cran-rpart
  Depends: r-cran-survival
  Depends: r-cran-mass
  Depends: r-cran-class
  Depends: r-cran-nnet
  Depends: r-cran-spatial
  Depends: r-cran-codetools
  Depends: r-cran-matrix
```

These packages do not seem to have any transitive dependencies. Diffing `dpkg -l` output after the two installs gives:

```diff
*** only-core.txt	2022-01-25 09:58:18.000000000 +0100
--- before.txt	2022-01-25 09:58:18.000000000 +0100
*************** ii  python3-lib2to3                    3
*** 407,414 ****
--- 407,431 ----
  ii  python3-minimal                    3.6.7-1~18.04                       amd64        minimal subset of the Python language (default python3 version)
  ii  python3.6                          3.6.9-1~18.04ubuntu1.6              amd64        Interactive high-level object-oriented language (version 3.6)
  ii  python3.6-minimal                  3.6.9-1~18.04ubuntu1.6              amd64        Minimal subset of the Python language (version 3.6)
+ ii  r-base                             4.0.5-1.1804.0                      all          GNU R statistical computation and graphics system
  ii  r-base-core                        4.0.5-1.1804.0                      amd64        GNU R core of statistical computation and graphics system
  ii  r-base-dev                         4.0.5-1.1804.0                      all          GNU R installation of auxiliary GNU R packages
+ ii  r-cran-boot                        1.3-28-1cran1.1804.0                all          GNU R package "Bootstrap Functions (Originally by Angelo
+ ii  r-cran-class                       7.3-19-1.1804.0                     amd64        GNU R package for classification
+ ii  r-cran-cluster                     2.1.2-1.1804.0                      amd64        GNU R package for cluster analysis by Rousseeuw et al
+ ii  r-cran-codetools                   0.2-18-1cran1.1804.0                all          GNU R package "Code Analysis Tools for R"
+ ii  r-cran-foreign                     0.8.82-1.1804.0                     amd64        GNU R package to read/write data from other stat. systems
+ ii  r-cran-kernsmooth                  2.23-20-1cran1.1804.0               amd64        GNU R package "Functions for Kernel Smoothing Supporting
+ ii  r-cran-lattice                     0.20-45-1.1804.0                    amd64        GNU R package for 'Trellis' graphics
+ ii  r-cran-mass                        7.3-54-1.1804.0                     amd64        GNU R package of Venables and Ripley's MASS
+ ii  r-cran-matrix                      1.4-0-1.1804.0                      amd64        GNU R package of classes for dense and sparse matrices
+ ii  r-cran-mgcv                        1.8-38-1.1804.0                     amd64        GNU R package for multiple parameter smoothing estimation
+ ii  r-cran-nlme                        3.1.155-1.1804.0                    amd64        GNU R package for (non-)linear mixed effects models
+ ii  r-cran-nnet                        7.3-16-1.1804.0                     amd64        GNU R package for feed-forward neural networks
+ ii  r-cran-rpart                       4.1-15-2bionic0                     amd64        GNU R package for recursive partitioning and regression trees
+ ii  r-cran-spatial                     7.3-11-2.1804.1                     amd64        GNU R package for spatial statistics
+ ii  r-cran-survival                    3.2-13-1cran1.1804.0                amd64        GNU R package "Survival Analysis"
+ ii  r-recommended                      4.0.5-1.1804.0                      all          GNU R collection of recommended packages [metapackage]
  ii  readline-common                    7.0-3                               all          GNU readline and history libraries, common files
  ii  sed                                4.4-2                               amd64        GNU stream editor for filtering/transforming text
  ii  sensible-utils                     0.0.12                              all          Utilities for sensible alternative selection
```

(`r-base` is an empty metapackage depending on `r-base-core` and `r-recommended`).

Dockerfile I used to test:

```docker
FROM buildpack-deps:bionic
RUN echo "deb https://cloud.r-project.org/bin/linux/ubuntu bionic-cran40/" > /etc/apt/sources.list.d/r-ubuntu.list \
 && wget --quiet -O - 'https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xe298a3a825c0d65dfd57cbb651716619e084dab9' | apt-key add - \
 && apt-get update
ENV V=4.0.5-1.1804.0
RUN apt-get --yes install --no-install-recommends r-base-core=$V r-base-dev=$V
RUN dpkg -l > /tmp/only-core.txt
RUN apt-get --yes install \
    r-base=$V \
    r-base-core=$V \
    r-base-dev=$V \
    r-recommended=$V \
    r-cran-mass=7.3-54-1.1804.0 \
    r-cran-class=7.3-19-1.1804.0 \
    r-cran-nnet=7.3-16-1.1804.0
RUN dpkg -l > /tmp/before.txt
```

</details>