### PR TITLE
Use a smaller R library in our tests

### DIFF
--- a/tests/conda/r3.6/environment.yml
+++ b/tests/conda/r3.6/environment.yml
@@ -1,3 +1,3 @@
 dependencies:
   - r-base=3.6
-  - r-ggplot2
+  - r-tinytest

--- a/tests/conda/r3.6/environment.yml
+++ b/tests/conda/r3.6/environment.yml
@@ -1,3 +1,3 @@
 dependencies:
   - r-base=3.6
-  - r-tinytest
+  - r-testthat

--- a/tests/conda/r3.6/verify
+++ b/tests/conda/r3.6/verify
@@ -2,6 +2,6 @@
 
 jupyter serverextension list 2>&1 | grep jupyter_server_proxy
 jupyter nbextension list 2>&1 | grep jupyter_server_proxy
-R -e "library('tinytest')"
+R -e "library('testthat')"
 # Fail if version is not 3.6
 R -e 'if (!(version$major == "3" && as.double(version$minor) >= 6 && as.double(version$minor) < 7)) quit("yes", 1)'

--- a/tests/conda/r3.6/verify
+++ b/tests/conda/r3.6/verify
@@ -2,6 +2,6 @@
 
 jupyter serverextension list 2>&1 | grep jupyter_server_proxy
 jupyter nbextension list 2>&1 | grep jupyter_server_proxy
-R -e "library('ggplot2')"
+R -e "library('tinytest')"
 # Fail if version is not 3.6
 R -e 'if (!(version$major == "3" && as.double(version$minor) >= 6 && as.double(version$minor) < 7)) quit("yes", 1)'

--- a/tests/r/mran/install.R
+++ b/tests/r/mran/install.R
@@ -1,1 +1,1 @@
-install.packages("ggplot2")
+install.packages("tinytest")

--- a/tests/r/mran/install.R
+++ b/tests/r/mran/install.R
@@ -1,1 +1,1 @@
-install.packages("tinytest")
+install.packages("testthat")

--- a/tests/r/mran/verify
+++ b/tests/r/mran/verify
@@ -1,5 +1,5 @@
 #!/usr/bin/env Rscript
-library('tinytest')
+library('testthat')
 
 print(version)
 

--- a/tests/r/mran/verify
+++ b/tests/r/mran/verify
@@ -1,5 +1,5 @@
 #!/usr/bin/env Rscript
-library('ggplot2')
+library('tinytest')
 
 print(version)
 

--- a/tests/r/r3.6/install.R
+++ b/tests/r/r3.6/install.R
@@ -1,1 +1,1 @@
-install.packages("ggplot2")
+install.packages("tinytest")

--- a/tests/r/r3.6/install.R
+++ b/tests/r/r3.6/install.R
@@ -1,1 +1,1 @@
-install.packages("tinytest")
+install.packages("testthat")

--- a/tests/r/r3.6/verify
+++ b/tests/r/r3.6/verify
@@ -1,5 +1,5 @@
 #!/usr/bin/env Rscript
-library('tinytest')
+library('testthat')
 
 print(version)
 # Fail if version is not 3.6

--- a/tests/r/r3.6/verify
+++ b/tests/r/r3.6/verify
@@ -1,5 +1,5 @@
 #!/usr/bin/env Rscript
-library('ggplot2')
+library('tinytest')
 
 print(version)
 # Fail if version is not 3.6

--- a/tests/r/r4.0-rspm/install.R
+++ b/tests/r/r4.0-rspm/install.R
@@ -1,1 +1,1 @@
-install.packages("ggplot2")
+install.packages("tinytest")

--- a/tests/r/r4.0-rspm/install.R
+++ b/tests/r/r4.0-rspm/install.R
@@ -1,1 +1,1 @@
-install.packages("tinytest")
+install.packages("testthat")

--- a/tests/r/r4.0-rspm/verify
+++ b/tests/r/r4.0-rspm/verify
@@ -1,5 +1,5 @@
 #!/usr/bin/env Rscript
-library('tinytest')
+library('testthat')
 
 print(version)
 # Fail if version is not 4.0

--- a/tests/r/r4.0-rspm/verify
+++ b/tests/r/r4.0-rspm/verify
@@ -1,5 +1,5 @@
 #!/usr/bin/env Rscript
-library('ggplot2')
+library('tinytest')
 
 print(version)
 # Fail if version is not 4.0

--- a/tests/r/r4.0/install.R
+++ b/tests/r/r4.0/install.R
@@ -1,1 +1,1 @@
-install.packages("ggplot2")
+install.packages("tinytest")

--- a/tests/r/r4.0/install.R
+++ b/tests/r/r4.0/install.R
@@ -1,1 +1,1 @@
-install.packages("tinytest")
+install.packages("testthat")

--- a/tests/r/r4.0/verify
+++ b/tests/r/r4.0/verify
@@ -1,5 +1,5 @@
 #!/usr/bin/env Rscript
-library('tinytest')
+library('testthat')
 
 print(version)
 # Fail if version is not 4.0

--- a/tests/r/r4.0/verify
+++ b/tests/r/r4.0/verify
@@ -1,5 +1,5 @@
 #!/usr/bin/env Rscript
-library('ggplot2')
+library('tinytest')
 
 print(version)
 # Fail if version is not 4.0

--- a/tests/r/r4.1/install.R
+++ b/tests/r/r4.1/install.R
@@ -1,1 +1,1 @@
-install.packages("ggplot2")
+install.packages("tinytest")

--- a/tests/r/r4.1/install.R
+++ b/tests/r/r4.1/install.R
@@ -1,1 +1,1 @@
-install.packages("tinytest")
+install.packages("testthat")

--- a/tests/r/r4.1/verify
+++ b/tests/r/r4.1/verify
@@ -1,5 +1,5 @@
 #!/usr/bin/env Rscript
-library('tinytest')
+library('testthat')
 
 # Fail if version is not 4.1
 if (!(version$major == "4" && as.double(version$minor) >= 1 && as.double(version$minor) < 2)) {

--- a/tests/r/r4.1/verify
+++ b/tests/r/r4.1/verify
@@ -1,5 +1,5 @@
 #!/usr/bin/env Rscript
-library('ggplot2')
+library('tinytest')
 
 # Fail if version is not 4.1
 if (!(version$major == "4" && as.double(version$minor) >= 1 && as.double(version$minor) < 2)) {

--- a/tests/r/simple/install.R
+++ b/tests/r/simple/install.R
@@ -1,1 +1,1 @@
-install.packages("ggplot2")
+install.packages("tinytest")

--- a/tests/r/simple/install.R
+++ b/tests/r/simple/install.R
@@ -1,1 +1,1 @@
-install.packages("tinytest")
+install.packages("testthat")

--- a/tests/r/simple/verify
+++ b/tests/r/simple/verify
@@ -1,5 +1,5 @@
 #!/usr/bin/env Rscript
-library('tinytest')
+library('testthat')
 
 # Fail if version is not 4.1
 if (!(version$major == "4" && as.double(version$minor) >= 1 && as.double(version$minor) < 2)) {

--- a/tests/r/simple/verify
+++ b/tests/r/simple/verify
@@ -1,5 +1,5 @@
 #!/usr/bin/env Rscript
-library('ggplot2')
+library('tinytest')
 
 # Fail if version is not 4.1
 if (!(version$major == "4" && as.double(version$minor) >= 1 && as.double(version$minor) < 2)) {


### PR DESCRIPTION
ggplot2 is a big library with a bunch of dependencies,
making our already slow R tests even slower. This PR
switches them to using the tinytest library, which has
no dependencies and is much smaller.

<!--

Our guide to getting a PR merged https://repo2docker.readthedocs.io/en/latest/contributing/contributing.html#guidelines-to-getting-a-pull-request-merged.

About to propose a big change? Read https://repo2docker.readthedocs.io/en/latest/contributing/contributing.html#process-for-making-a-contribution to maximise the chances of it getting merged quickly.

-->
