### PR TITLE
Remove deprecated calls to distutils

### DIFF
--- a/repo2docker/buildpacks/_r_base.py
+++ b/repo2docker/buildpacks/_r_base.py
@@ -3,7 +3,7 @@ Base information for using R in BuildPacks.
 
 Keeping this in r.py would lead to cyclic imports.
 """
-from distutils.version import LooseVersion as V
+from ..semver import parse_version as V
 
 
 def rstudio_base_scripts(r_version):

--- a/repo2docker/buildpacks/julia/julia_project.py
+++ b/repo2docker/buildpacks/julia/julia_project.py
@@ -1,10 +1,13 @@
 """Generates a Dockerfile based on an input matrix for Julia"""
 import functools
 import os
+
 import requests
+import semver
 import toml
+
 from ..python import PythonBuildPack
-from .semver import find_semver_match, semver
+from ...semver import find_semver_match
 
 
 class JuliaProjectTomlBuildPack(PythonBuildPack):

--- a/repo2docker/buildpacks/julia/julia_require.py
+++ b/repo2docker/buildpacks/julia/julia_require.py
@@ -1,9 +1,9 @@
 """Generates a Dockerfile based on an input matrix with REQUIRE for legacy Julia"""
 
-from distutils.version import LooseVersion as V
 import os
 
 from ..python import PythonBuildPack
+from ...semver import parse_version as V
 
 
 class JuliaRequireBuildPack(PythonBuildPack):

--- a/repo2docker/buildpacks/r.py
+++ b/repo2docker/buildpacks/r.py
@@ -3,8 +3,8 @@ import os
 import datetime
 import requests
 
-from distutils.version import LooseVersion as V
 
+from ..semver import parse_version as V
 from .python import PythonBuildPack
 from ._r_base import rstudio_base_scripts
 

--- a/tests/unit/contentproviders/test_mercurial.py
+++ b/tests/unit/contentproviders/test_mercurial.py
@@ -1,15 +1,20 @@
-from pathlib import Path
-import subprocess
-from tempfile import TemporaryDirectory
 import os
-from distutils.util import strtobool
+import subprocess
+from pathlib import Path
+from tempfile import TemporaryDirectory
 
 import pytest
 
 from repo2docker.contentproviders import Mercurial
 from repo2docker.contentproviders.mercurial import args_enabling_topic
 
-SKIP_HG = strtobool(os.environ.get("REPO2DOCKER_SKIP_HG_TESTS", "False"))
+
+SKIP_HG = os.environ.get("REPO2DOCKER_SKIP_HG_TESTS", "").lower() not in {
+    "",
+    "0",
+    "false",
+    "no",
+}
 
 skip_if_no_hg_tests = pytest.mark.skipif(
     SKIP_HG,

--- a/tests/unit/test_semver.py
+++ b/tests/unit/test_semver.py
@@ -1,5 +1,6 @@
 import pytest
-from repo2docker.buildpacks.julia import semver
+from semver import VersionInfo
+from repo2docker import semver
 
 
 @pytest.mark.parametrize("test_input, expected", [("1.5.2", (1, 5, 2)), ("1", (1,))])
@@ -145,3 +146,20 @@ def test_largerthan_equal():
         semver.create_semver_matcher(">=1.2.3").match(semver.str_to_version("1.2.2"))
         == False
     )
+
+
+@pytest.mark.parametrize(
+    "vstr, expected",
+    [
+        ("1.2.3", "1.2.3"),
+        ("1.2", "1.2.0"),
+        ("1", "1.0.0"),
+    ],
+)
+def test_parse_version(vstr, expected):
+    version_info = semver.parse_version(vstr)
+    assert isinstance(version_info, semver.semver.VersionInfo)
+    assert str(version_info) == expected
+    # satisfies itself, since this is how we use it
+    assert semver.parse_version(expected) <= version_info
+    assert semver.parse_version(expected) >= version_info


### PR DESCRIPTION
Python is removing all version-string parsing from the standard library, so use the semver utilities we already have for Julia.

Had to add some zero-padding, because `semver.VersionInfo.parse` is unnecessarily pedantic and doesn't accept '1' or '1.0', only '1.0.0'.

