### PR TITLE
Allow passing in traitlets via commandline

### DIFF
--- a/repo2docker/__main__.py
+++ b/repo2docker/__main__.py
@@ -67,6 +67,20 @@ def get_argparser():
     )
 
     argparser.add_argument(
+        "--help-all",
+        dest="help_all",
+        action="store_true",
+        help="Display all configurable options and exit.",
+    )
+
+    argparser.add_argument(
+        "--version",
+        dest="version",
+        action="store_true",
+        help="Print the repo2docker version and exit.",
+    )
+
+    argparser.add_argument(
         "--config",
         default="repo2docker_config.py",
         help="Path to config file for repo2docker",
@@ -223,13 +237,6 @@ def get_argparser():
     argparser.add_argument("--subdir", type=str, help=Repo2Docker.subdir.help)
 
     argparser.add_argument(
-        "--version",
-        dest="version",
-        action="store_true",
-        help="Print the repo2docker version and exit.",
-    )
-
-    argparser.add_argument(
         "--cache-from", action="append", default=[], help=Repo2Docker.cache_from.help
     )
 
@@ -245,13 +252,21 @@ def make_r2d(argv=None):
     if argv is None:
         argv = sys.argv[1:]
 
+    argparser = get_argparser()
+
     # version must be checked before parse, as repo/cmd are required and
     # will spit out an error if allowed to be parsed first.
     if "--version" in argv:
         print(__version__)
         sys.exit(0)
 
-    args, traitlet_args = get_argparser().parse_known_args(argv)
+    if "--help-all" in argv:
+        argparser.print_help()
+        print("\nAll configurable options:\n")
+        Repo2Docker().print_help(classes=True)
+        sys.exit(0)
+
+    args, traitlet_args = argparser.parse_known_args(argv)
 
     r2d = Repo2Docker()
     r2d.parse_command_line(traitlet_args)

--- a/repo2docker/__main__.py
+++ b/repo2docker/__main__.py
@@ -251,9 +251,10 @@ def make_r2d(argv=None):
         print(__version__)
         sys.exit(0)
 
-    args = get_argparser().parse_args(argv)
+    args, traitlet_args = get_argparser().parse_known_args(argv)
 
     r2d = Repo2Docker()
+    r2d.parse_command_line(traitlet_args)
 
     if args.debug:
         r2d.log_level = logging.DEBUG

--- a/repo2docker/app.py
+++ b/repo2docker/app.py
@@ -490,7 +490,7 @@ class Repo2Docker(Application):
             extra=dict(phase="failed"),
         )
 
-    def initialize(self):
+    def initialize(self, *args, **kwargs):
         """Init repo2docker configuration before start"""
         # FIXME: Remove this function, move it to setters / traitlet reactors
         if self.json_logs:

--- a/repo2docker/app.py
+++ b/repo2docker/app.py
@@ -47,6 +47,10 @@ class Repo2Docker(Application):
     name = "jupyter-repo2docker"
     version = __version__
     description = __doc__
+    # disable aliases/flags because we don't use the traitlets for CLI parsing
+    # other than --Class.trait=value
+    aliases = {}
+    flags = {}
 
     @default("log_level")
     def _default_log_level(self):


### PR DESCRIPTION
Without this, you *always* needed a repo2docker_config.py
file to configure anything. This PR makes r2d match the
behavior of most traitlets based applications (like jupyter_server,
jupyterhub, nbconvert, etc)

Fixes https://github.com/jupyterhub/repo2docker/issues/1112

<!--

Our guide to getting a PR merged https://repo2docker.readthedocs.io/en/latest/contributing/contributing.html#guidelines-to-getting-a-pull-request-merged.

About to propose a big change? Read https://repo2docker.readthedocs.io/en/latest/contributing/contributing.html#process-for-making-a-contribution to maximise the chances of it getting merged quickly.

-->
