### PR TITLE
Allow passing in extra args to Docker initialization

### DIFF
--- a/repo2docker/docker.py
+++ b/repo2docker/docker.py
@@ -73,7 +73,8 @@ class DockerEngine(ContainerEngine):
         try:
             kwargs = docker.utils.kwargs_from_env()
             kwargs.update(self.extra_init_args)
-            self._apiclient = docker.APIClient(version="auto", **kwargs)
+            kwargs.setdefault("version", "auto")
+            self._apiclient = docker.APIClient(**kwargs)
         except docker.errors.DockerException as e:
             raise ContainerEngineException("Check if docker is running on the host.", e)
 

--- a/repo2docker/docker.py
+++ b/repo2docker/docker.py
@@ -3,6 +3,7 @@ Docker container engine for repo2docker
 """
 
 import docker
+from traitlets import Dict
 from iso8601 import parse_date
 
 from .engine import Container, ContainerEngine, ContainerEngineException, Image
@@ -53,12 +54,26 @@ class DockerEngine(ContainerEngine):
 
     string_output = False
 
+    extra_init_args = Dict(
+        {},
+        help="""
+        Extra kwargs to pass to docker client when initializing it.
+
+        Dictionary that allows users to specify extra parameters to pass
+        to APIClient, parameters listed in https://docker-py.readthedocs.io/en/stable/api.html#docker.api.client.APIClient.
+
+        Parameters here are merged with whatever is picked up from the
+        environment.
+        """,
+        config=True,
+    )
+
     def __init__(self, *, parent):
         super().__init__(parent=parent)
         try:
-            self._apiclient = docker.APIClient(
-                version="auto", **docker.utils.kwargs_from_env()
-            )
+            kwargs = docker.utils.kwargs_from_env()
+            kwargs.update(self.extra_init_args)
+            self._apiclient = docker.APIClient(version="auto", **kwargs)
         except docker.errors.DockerException as e:
             raise ContainerEngineException("Check if docker is running on the host.", e)
 


### PR DESCRIPTION
Puts it in the ContainerEngine interface specific to Docker,
so PodMan can implement its own when necessary.

Fixes https://github.com/jupyterhub/repo2docker/issues/711

<!--

Our guide to getting a PR merged https://repo2docker.readthedocs.io/en/latest/contributing/contributing.html#guidelines-to-getting-a-pull-request-merged.

About to propose a big change? Read https://repo2docker.readthedocs.io/en/latest/contributing/contributing.html#process-for-making-a-contribution to maximise the chances of it getting merged quickly.

-->
