### PR TITLE
Add check-tmp step to local repo tests

### DIFF
--- a/repo2docker/buildpacks/_r_base.py
+++ b/repo2docker/buildpacks/_r_base.py
@@ -33,7 +33,7 @@ def rstudio_base_scripts(r_version):
             echo '{shiny_sha256sum} /tmp/shiny.deb' | sha256sum -c - && \
             apt-get update > /dev/null && \
             apt install -y --no-install-recommends /tmp/rstudio.deb /tmp/shiny.deb && \
-            rm /tmp/rstudio.deb && \
+            rm /tmp/*.deb && \
             apt-get -qq purge && \
             apt-get -qq clean && \
             rm -rf /var/lib/apt/lists/*

--- a/repo2docker/buildpacks/pipfile/__init__.py
+++ b/repo2docker/buildpacks/pipfile/__init__.py
@@ -88,7 +88,10 @@ class PipfileBuildPack(CondaBuildPack):
         scripts = super().get_preassemble_scripts()
         # install pipenv to install dependencies within Pipfile.lock or Pipfile
         scripts.append(
-            ("${NB_USER}", "${KERNEL_PYTHON_PREFIX}/bin/pip install pipenv==2018.11.26")
+            (
+                "${NB_USER}",
+                "${KERNEL_PYTHON_PREFIX}/bin/pip install --no-cache-dir pipenv==2018.11.26",
+            )
         )
         return scripts
 

--- a/repo2docker/buildpacks/pipfile/__init__.py
+++ b/repo2docker/buildpacks/pipfile/__init__.py
@@ -11,6 +11,7 @@ import re
 
 import toml
 
+from ...semver import parse_version as V
 from ..conda import CondaBuildPack
 
 VERSION_PAT = re.compile(r"\d+(\.\d+)*")
@@ -87,10 +88,15 @@ class PipfileBuildPack(CondaBuildPack):
         """scripts to run prior to staging the repo contents"""
         scripts = super().get_preassemble_scripts()
         # install pipenv to install dependencies within Pipfile.lock or Pipfile
+        if V(self.python_version) < V("3.6"):
+            # last pipenv version to support 2.7, 3.5
+            pipenv_version = "2021.5.29"
+        else:
+            pipenv_version = "2022.1.8"
         scripts.append(
             (
                 "${NB_USER}",
-                "${KERNEL_PYTHON_PREFIX}/bin/pip install --no-cache-dir pipenv==2018.11.26",
+                f"${{KERNEL_PYTHON_PREFIX}}/bin/pip install --no-cache-dir pipenv=={pipenv_version}",
             )
         )
         return scripts

--- a/tests/check-tmp
+++ b/tests/check-tmp
@@ -50,11 +50,11 @@ def check_dir_size(path):
     path = os.path.expanduser(path)
 
     if not os.path.exists(path):
-        print(f"{path}: missing OK")
+        print("{path}: missing OK".format(**locals()))
         return True
 
     size_mb = du(path)
-    print(f"{path}: {size_mb:.1f} MB", end=" ")
+    print("{path}: {size_mb:.1f} MB".format(**locals()), end=" ")
     if size_mb <= THRESHOLD:
         print("OK")
         return True
@@ -66,7 +66,7 @@ def check_dir_size(path):
             if os.path.isfile(subpath):
                 file_sz = os.stat(subpath).st_size / MB
                 if file_sz > 0.1:
-                    print(f"  {file_sz:.1f}M {subpath}")
+                    print("  {file_sz:.1f}M {subpath}".format(**locals()))
         # get report on all subdirs that are at least 100k
         print(
             indent(

--- a/tests/check-tmp
+++ b/tests/check-tmp
@@ -25,10 +25,12 @@ MB = 1024 * 1024
 # missing is okay
 PATHS = [
     "/tmp/",
+    # check whole home?
+    # this shouldn't be empty, but  for our tests (so far) it should be very small
+    # This is the easiest way to ensure we aren't leaving any unexpected files
+    # without knowing ahead of time where all possible caches might be (.npm, .cache, etc.)
     "~/",
-    "~/.cache/",
-    # not running with read permissions on root
-    # "/root/",
+    "/root/",
 ]
 
 

--- a/tests/check-tmp
+++ b/tests/check-tmp
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""
+Script to check for leftover files
+
+Checks a collection of temporary or cache directories,
+to ensure we aren't wasting image size by forgetting cleanup steps.
+
+This script is run in every local repo image we test
+"""
+
+import os
+import sys
+from subprocess import check_output
+from textwrap import indent
+
+# directories larger than this are considered a failure
+# a few little files here aren't a problem
+THRESHOLD = 1  # in MB
+
+MB = 1024 * 1024
+
+# the paths to check
+# all of these locations
+# should be cleaned up
+# missing is okay
+PATHS = [
+    "/tmp/",
+    "~/",
+    "~/.cache/",
+    # not running with read permissions on root
+    # "/root/",
+]
+
+
+def du(path):
+    """Return disk usage in megabytes of a path"""
+    # -ks: get total size, reported in kilobytes
+    out = check_output(["du", "-Hks", path])
+    return int(out.split(None, 1)[0]) / 1024
+
+
+def check_dir_size(path):
+    """Check the size of a directory
+
+    Returns:
+
+    True: directory size is below THRESHOLD or is missing
+    False: directory is larger than THRESHOLD
+    """
+    path = os.path.expanduser(path)
+
+    if not os.path.exists(path):
+        print(f"{path}: missing OK")
+        return True
+
+    size_mb = du(path)
+    print(f"{path}: {size_mb:.1f} MB", end=" ")
+    if size_mb <= THRESHOLD:
+        print("OK")
+        return True
+    else:
+        print("FAIL")
+        # check size of files one-level deep (du only reports dirs)
+        for name in os.listdir(path):
+            subpath = os.path.join(path, name)
+            if os.path.isfile(subpath):
+                file_sz = os.stat(subpath).st_size / MB
+                if file_sz > 0.1:
+                    print(f"  {file_sz:.1f}M {subpath}")
+        # get report on all subdirs that are at least 100k
+        print(
+            indent(
+                check_output(["du", "-Hh", "-t", "100000", path]).decode("utf8"), "  "
+            )
+        )
+        return False
+
+
+def main():
+    results = [check_dir_size(path) for path in PATHS]
+    if not all(results):
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/venv/postBuild/postBuild
+++ b/tests/venv/postBuild/postBuild
@@ -1,3 +1,4 @@
 #!/bin/bash
 jupyter nbextension enable --py --sys-prefix ipyleaflet
 npm install --global configurable-http-proxy
+npm cache clean --force


### PR DESCRIPTION
This mostly lays the _infrastructure_ for #1121 


- re-use images and skip build stage in verify/check-tmp tests Should save some time, even though the build cache would have been used.  This way, we don't run through the build to check the layer cache.
- check-tmp checks disk usage in a collection of directories and fails if they exceed a certain size, reporting on their contents


What dirs should we check?

---

EDIT: closes #1207