### PR TITLE
[MRG] Update Dockerfile to current Alpine (ALPINE_VERSION=3.15.0)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG ALPINE_VERSION=3.12.0
+ARG ALPINE_VERSION=3.15.0
 FROM alpine:${ALPINE_VERSION}
 
 RUN apk add --no-cache git python3 python3-dev py-pip build-base


### PR DESCRIPTION
In order to use podman as a backend for repo2docker (a la https://github.com/manics/repo2podman),
a minimum version of Alpine 3.14 is needed.
