### PR TITLE
handle r version being unspecified in environment.yml

### DIFF
--- a/repo2docker/buildpacks/_r_base.py
+++ b/repo2docker/buildpacks/_r_base.py
@@ -14,7 +14,7 @@ def rstudio_base_scripts(r_version):
     shiny_proxy_version = "1.1"
     shiny_sha256sum = "80f1e48f6c824be7ef9c843bb7911d4981ac7e8a963e0eff823936a8b28476ee"
 
-    if V(r_version) <= V("4.1"):
+    if r_version and V(r_version) <= V("4.1"):
         # Older RStudio and jupyter-rsession-proxy for v4.1 and below
         rstudio_url = "https://download2.rstudio.org/server/bionic/amd64/rstudio-server-1.3.959-amd64.deb"
         rstudio_sha256sum = (

--- a/tests/conda/r-unspecified/environment.yml
+++ b/tests/conda/r-unspecified/environment.yml
@@ -1,0 +1,3 @@
+dependencies:
+  - r-base
+  - r-ggplot2

--- a/tests/conda/r-unspecified/verify
+++ b/tests/conda/r-unspecified/verify
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+jupyter serverextension list 2>&1 | grep jupyter_server_proxy
+jupyter nbextension list 2>&1 | grep jupyter_server_proxy
+R -e "library('ggplot2')"
+# Fail if version is not at least 4.1
+R -e 'if (!(version$major == "4" && as.double(version$minor) >= 1)) quit("yes", 1)'


### PR DESCRIPTION
when getting r-base from conda, `self.r_version` may be a falsy empty string. We can't do version comparisons when we don't have a version to compare!

closes #1140