### PR TITLE
handle permission issue writing .jupyter-server-log.txt in REPO_DIR

### DIFF
--- a/repo2docker/buildpacks/repo2docker-entrypoint
+++ b/repo2docker/buildpacks/repo2docker-entrypoint
@@ -23,11 +23,13 @@ SIGNALS = set(signal.Signals) - {signal.SIGKILL, signal.SIGSTOP, signal.SIGCHLD}
 
 def main():
 
-    # open log file to send output
-    log_file = open(
-        os.path.join(os.environ.get("REPO_DIR", "."), ".jupyter-server-log.txt"),
-        "ab",
-    )
+    # open log file to send output; fall back to writing it in
+    # the current working directory
+    if "REPO_DIR" in os.environ and os.access(os.environ["REPO_DIR"], 7):
+        log_path = os.path.join(os.environ["REPO_DIR"], ".jupyter-server-log.txt")
+    else:
+        log_path = os.path.join(".", ".jupyter-server-log.txt")
+    log_file = open(log_path, "ab")
 
     # build the command
     # like `exec "$@"`

--- a/repo2docker/buildpacks/repo2docker-entrypoint
+++ b/repo2docker/buildpacks/repo2docker-entrypoint
@@ -12,6 +12,7 @@ import select
 import signal
 import subprocess
 import sys
+import tempfile
 
 # output chunk size to read
 CHUNK_SIZE = 1024
@@ -23,13 +24,20 @@ SIGNALS = set(signal.Signals) - {signal.SIGKILL, signal.SIGSTOP, signal.SIGCHLD}
 
 def main():
 
-    # open log file to send output; fall back to writing it in
-    # the current working directory
-    if "REPO_DIR" in os.environ and os.access(os.environ["REPO_DIR"], 7):
-        log_path = os.path.join(os.environ["REPO_DIR"], ".jupyter-server-log.txt")
-    else:
-        log_path = os.path.join(".", ".jupyter-server-log.txt")
-    log_file = open(log_path, "ab")
+    # open log file to send output; iterate through different
+    # base locations
+    log_dirs = [".", tempfile.gettempdir()]
+    if "REPO_DIR" in os.environ:
+        log_dirs.insert(os.environ["REPO_DIR"], 0)
+    for d in log_dirs:
+        log_path = join(d, 'log.txt')
+        try:
+            log_file = open(log_path, "ab")
+        except PermissionError:
+            continue
+        else:
+            # success
+            break
 
     # build the command
     # like `exec "$@"`

--- a/repo2docker/buildpacks/repo2docker-entrypoint
+++ b/repo2docker/buildpacks/repo2docker-entrypoint
@@ -33,7 +33,7 @@ def main():
     if "REPO_DIR" in os.environ:
         log_dirs.insert(0, os.environ["REPO_DIR"])
     for d in log_dirs:
-        log_path = os.path.join(d, 'log.txt')
+        log_path = os.path.join(d, ".jupyter-server-log.txt")
         try:
             log_file = open(log_path, "ab")
         except PermissionError:

--- a/repo2docker/buildpacks/repo2docker-entrypoint
+++ b/repo2docker/buildpacks/repo2docker-entrypoint
@@ -28,7 +28,7 @@ def main():
     # base locations
     log_dirs = [".", tempfile.gettempdir()]
     if "REPO_DIR" in os.environ:
-        log_dirs.insert(os.environ["REPO_DIR"], 0)
+        log_dirs.insert(0, os.environ["REPO_DIR"])
     for d in log_dirs:
         log_path = join(d, 'log.txt')
         try:

--- a/repo2docker/buildpacks/repo2docker-entrypoint
+++ b/repo2docker/buildpacks/repo2docker-entrypoint
@@ -30,7 +30,7 @@ def main():
     if "REPO_DIR" in os.environ:
         log_dirs.insert(0, os.environ["REPO_DIR"])
     for d in log_dirs:
-        log_path = join(d, 'log.txt')
+        log_path = os.path.join(d, 'log.txt')
         try:
             log_file = open(log_path, "ab")
         except PermissionError:

--- a/repo2docker/buildpacks/repo2docker-entrypoint
+++ b/repo2docker/buildpacks/repo2docker-entrypoint
@@ -24,8 +24,11 @@ SIGNALS = set(signal.Signals) - {signal.SIGKILL, signal.SIGSTOP, signal.SIGCHLD}
 
 def main():
 
-    # open log file to send output; iterate through different
-    # base locations
+    # open log file to send output to;
+    # preferred location of log file is:
+    #  1. REPO_DIR env variable
+    #  2. current working directory: "."
+    #  3. default temp directory for the OS (e.g. /tmp for linux)
     log_dirs = [".", tempfile.gettempdir()]
     if "REPO_DIR" in os.environ:
         log_dirs.insert(0, os.environ["REPO_DIR"])


### PR DESCRIPTION
<!--

Our guide to getting a PR merged https://repo2docker.readthedocs.io/en/latest/contributing/contributing.html#guidelines-to-getting-a-pull-request-merged.

About to propose a big change? Read https://repo2docker.readthedocs.io/en/latest/contributing/contributing.html#process-for-making-a-contribution to maximise the chances of it getting merged quickly.

-->
This PR addresses an issue in the docker entrypoint where the `REPO_DIR` in the container is owned by the `NB_USER`'s default UID and GID but the `-u` option to docker was specified to override the `NB_USER`'s UID and GID. Without this fix:

```
docker \
    run \
    -i \
    -v \
    --mount=type=bind,source=/tmp/t9ig2rxb,target=/kvyoQW \
    --mount=type=bind,source=/tmp/tuafqr29,target=/tmp \
    --workdir=/kvyoQW \
    --user=4001:4001 \
    --rm \
    --cidfile=/tmp/vsiq7g3w/20220415125043-084473.cid \
    --env=TMPDIR=/tmp \
    --env=HOME=/kvyoQW \
    pymonger/downsample-landsat:2.0.3 \
    /bin/sh \
    -c \
    papermill /home/jovyan/downsample-landsat/stage_in.ipynb output_nb.ipynb --parameters input_url "https://github.com/pymonger/downsample-landsat/releases/download/1.0.0/LC08_L1TP_065045_20211205_20211215_02_T1_QA_PIXEL.TIF"
Traceback (most recent call last):
  File "/usr/local/bin/repo2docker-entrypoint", line 97, in <module>
    main()
  File "/usr/local/bin/repo2docker-entrypoint", line 29, in main
    "ab",
PermissionError: [Errno 13] Permission denied: '/home/jovyan/downsample-landsat/.jupyter-server-log.txt'
```