### PR TITLE
[MRG] Shallow clone HEAD

### DIFF
--- a/repo2docker/contentproviders/git.py
+++ b/repo2docker/contentproviders/git.py
@@ -1,5 +1,4 @@
 import subprocess
-import sys
 
 from .base import ContentProvider, ContentProviderException
 from ..utils import execute_cmd, check_ref

--- a/repo2docker/contentproviders/git.py
+++ b/repo2docker/contentproviders/git.py
@@ -17,12 +17,12 @@ class Git(ContentProvider):
 
     def fetch(self, spec, output_dir, yield_output=False):
         repo = spec["repo"]
-        ref = spec.get("ref", None)
+        ref = spec.get("ref") or "HEAD"
 
         # make a, possibly shallow, clone of the remote repository
         try:
             cmd = ["git", "clone"]
-            if ref is None:
+            if ref == "HEAD":
                 # check out of HEAD is performed after the clone is complete
                 cmd.extend(["--depth", "1"])
             else:
@@ -35,13 +35,13 @@ class Git(ContentProvider):
 
         except subprocess.CalledProcessError as e:
             msg = "Failed to clone repository from {repo}".format(repo=repo)
-            if ref is not None:
+            if ref != "HEAD":
                 msg += " (ref {ref})".format(ref=ref)
             msg += "."
             raise ContentProviderException(msg) from e
 
         # check out the specific ref given by the user
-        if ref is not None:
+        if ref != "HEAD":
             hash = check_ref(ref, output_dir)
             if hash is None:
                 self.log.error(

--- a/tests/unit/test_clone_depth.py
+++ b/tests/unit/test_clone_depth.py
@@ -1,5 +1,5 @@
 """
-Test that a clone depth of 1 is used and good enough when no refspec is used
+Test that a clone depth of 1 is used when HEAD or no refspec is used
 
 Note: the tests don't actually run the container. Building the
 container requires a specific repository and commit to be checked out,
@@ -25,7 +25,34 @@ def test_clone_depth():
             repo=URL,
             dry_run=True,
             run=False,
-            # turn of automatic clean up of the checkout so we can inspect it
+            # turn off automatic clean up of the checkout so we can inspect it
+            # we also set the work directory explicitly so we know where to look
+            cleanup_checkout=False,
+            git_workdir=d,
+        )
+        app.initialize()
+        app.start()
+
+        cmd = ["git", "rev-parse", "HEAD"]
+        p = subprocess.run(cmd, stdout=subprocess.PIPE, cwd=d)
+        assert p.stdout.strip() == b"703322e9c6635ba1835d3b92eafbabeca0042c3e"
+        cmd = ["git", "rev-list", "--count", "HEAD"]
+        p = subprocess.run(cmd, stdout=subprocess.PIPE, cwd=d)
+        assert p.stdout.strip() == b"1"
+        with open(os.path.join(d, "COMMIT")) as fp:
+            assert fp.read() == "100\n"
+
+
+def test_clone_depth_head():
+    """Test a remote repository, with a refspec of 'HEAD'"""
+
+    with TemporaryDirectory() as d:
+        app = Repo2Docker(
+            repo=URL,
+            ref="HEAD",
+            dry_run=True,
+            run=False,
+            # turn off automatic clean up of the checkout so we can inspect it
             # we also set the work directory explicitly so we know where to look
             cleanup_checkout=False,
             git_workdir=d,
@@ -52,7 +79,7 @@ def test_clone_depth_full():
             ref="master",
             dry_run=True,
             run=False,
-            # turn of automatic clean up of the checkout so we can inspect it
+            # turn off automatic clean up of the checkout so we can inspect it
             # we also set the work directory explicitly so we know where to look
             cleanup_checkout=False,
             git_workdir=d,
@@ -80,7 +107,7 @@ def test_clone_depth_full2():
             ref="703322e",
             dry_run=True,
             run=False,
-            # turn of automatic clean up of the checkout so we can inspect it
+            # turn off automatic clean up of the checkout so we can inspect it
             # we also set the work directory explicitly so we know where to look
             cleanup_checkout=False,
             git_workdir=d,
@@ -108,7 +135,7 @@ def test_clone_depth_mid():
             ref="8bc4f21",
             dry_run=True,
             run=False,
-            # turn of automatic clean up of the checkout so we can inspect it
+            # turn off automatic clean up of the checkout so we can inspect it
             # we also set the work directory explicitly so we know where to look
             cleanup_checkout=False,
             git_workdir=d,


### PR DESCRIPTION
Previously repo2docker only performed shallow clones when refspec was not provided (#420). We now also perform shallow clones if refspec is explicitly set to `HEAD`. BinderHub always specifies a refspec, often `HEAD`, so this should improve some build times.

See #1159 for extending shallow clones/fetches to other refspecs.