### PR TITLE
Remove outdated comment about Docker 17.09 syntax

### DIFF
--- a/repo2docker/buildpacks/base.py
+++ b/repo2docker/buildpacks/base.py
@@ -10,7 +10,6 @@ import sys
 import hashlib
 import escapism
 
-# Only use syntax features supported by Docker 17.09
 TEMPLATE = r"""
 FROM buildpack-deps:bionic
 


### PR DESCRIPTION
We've already been using newer syntax for a while (--chown)
