### PR TITLE
ci: switch to using a 2fa enabled accounts pypi api-token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
         if: startsWith(github.ref, 'refs/tags')
         uses: pypa/gh-action-pypi-publish@master
         with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
+          password: ${{ secrets.PYPI_PASSWORD }}
 
   publish-docker:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
In the settings for this project, there were two separate api tokens setup for this project. One stemming from `mybinderteam` account in PyPI, and one for `jupyterhub-bot`. Only the latter has 2FA enabled, so in this PR I'm switching to using that PyPI API token instead and have removed `mybinderteam` on PyPI to have access to this package.

### Related
- https://github.com/jupyterhub/repo2docker/settings/secrets/actions
- https://github.com/jupyterhub/team-compass/issues/539