### PR TITLE
Use full path to `buildpack-deps:bionic`

### DIFF
--- a/repo2docker/buildpacks/base.py
+++ b/repo2docker/buildpacks/base.py
@@ -12,7 +12,7 @@ import escapism
 
 # Only use syntax features supported by Docker 17.09
 TEMPLATE = r"""
-FROM buildpack-deps:bionic
+FROM docker.io/library/buildpack-deps:bionic
 
 # Avoid prompts from apt
 ENV DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
Non-default engines may require the full path including registry

Closes https://github.com/jupyterhub/repo2docker/issues/1146