### PR TITLE
Support pulling from zenodo sandbox too

### DIFF
--- a/repo2docker/contentproviders/zenodo.py
+++ b/repo2docker/contentproviders/zenodo.py
@@ -21,6 +21,17 @@ class Zenodo(DoiProvider):
         # metadata), download (path to file download URL), and type (path to item type in metadata)
         self.hosts = [
             {
+                "hostname": [
+                    "https://sandbox.zenodo.org/record/",
+                    "http://sandbox.zenodo.org/record/",
+                ],
+                "api": "https://sandbox.zenodo.org/api/records/",
+                "filepath": "files",
+                "filename": "filename",
+                "download": "links.download",
+                "type": "metadata.upload_type",
+            },
+            {
                 "hostname": ["https://zenodo.org/record/", "http://zenodo.org/record/"],
                 "api": "https://zenodo.org/api/records/",
                 "filepath": "files",

--- a/tests/unit/contentproviders/test_zenodo.py
+++ b/tests/unit/contentproviders/test_zenodo.py
@@ -46,7 +46,7 @@ test_hosts = [
             "10.5281/zenodo.3232985",
             "https://doi.org/10.5281/zenodo.3232985",
         ],
-        {"host": test_zen.hosts[0], "record": "3232985"},
+        {"host": test_zen.hosts[1], "record": "3232985"},
     ),
     (
         [
@@ -54,7 +54,7 @@ test_hosts = [
             "10.22002/d1.1235",
             "https://doi.org/10.22002/d1.1235",
         ],
-        {"host": test_zen.hosts[1], "record": "1235"},
+        {"host": test_zen.hosts[2], "record": "1235"},
     ),
 ]
 
@@ -107,7 +107,7 @@ def test_fetch_software_from_github_archive(requests_mock):
         )
 
         zen = Zenodo()
-        spec = {"host": test_zen.hosts[0], "record": "1234"}
+        spec = {"host": test_zen.hosts[1], "record": "1234"}
 
         with TemporaryDirectory() as d:
             output = []
@@ -141,7 +141,7 @@ def test_fetch_software(requests_mock):
 
         with TemporaryDirectory() as d:
             zen = Zenodo()
-            spec = spec = {"host": test_zen.hosts[0], "record": "1234"}
+            spec = spec = {"host": test_zen.hosts[1], "record": "1234"}
             output = []
             for l in zen.fetch(spec, d):
                 output.append(l)
@@ -178,7 +178,7 @@ def test_fetch_data(requests_mock):
 
             with TemporaryDirectory() as d:
                 zen = Zenodo()
-                spec = {"host": test_zen.hosts[0], "record": "1234"}
+                spec = {"host": test_zen.hosts[1], "record": "1234"}
                 output = []
                 for l in zen.fetch(spec, d):
                     output.append(l)


### PR DESCRIPTION
Test uploads should go to the sandbox, rather than to
main zenodo. The installation is exactly the same.

<!--

Our guide to getting a PR merged https://repo2docker.readthedocs.io/en/latest/contributing/contributing.html#guidelines-to-getting-a-pull-request-merged.

About to propose a big change? Read https://repo2docker.readthedocs.io/en/latest/contributing/contributing.html#process-for-making-a-contribution to maximise the chances of it getting merged quickly.

-->
