### PR TITLE
Freeze.py update

### DIFF
--- a/repo2docker/buildpacks/conda/freeze.py
+++ b/repo2docker/buildpacks/conda/freeze.py
@@ -118,7 +118,7 @@ if __name__ == "__main__":
         "py",
         nargs="*",
         help="Python version(s) to update and freeze",
-        default=("2.7", "3.6", "3.7", "3.8", "3.9"),
+        default=("2.7", "3.7", "3.8", "3.9"),
     )
     args = parser.parse_args()
     default_py = "3.7"

--- a/repo2docker/buildpacks/conda/freeze.py
+++ b/repo2docker/buildpacks/conda/freeze.py
@@ -62,6 +62,7 @@ def freeze(env_file, frozen_file, platform="linux-64"):
             # FIXME: adopt micromamba after ordering is fixed
             # https://github.com/conda-incubator/conda-lock/issues/79
             "--mamba",
+            "--kind=explicit",
             f"--platform={platform}",
             f"--filename-template={frozen_template}",
             f"--file={env_file}",


### PR DESCRIPTION
The latest conda-lock needs `--kind=explicit` to match the current expectations of `freeze.py` (originally written for conda-lock 0.8): https://github.com/conda-incubator/conda-lock#pre-10-compatible-usage-explicit-per-platform-locks

The Python 3.6 lockfile was removed in https://github.com/jupyterhub/repo2docker/pull/1149