### PR TITLE
explicitly build linux/amd64 images

### DIFF
--- a/repo2docker/docker.py
+++ b/repo2docker/docker.py
@@ -105,6 +105,7 @@ class DockerEngine(ContainerEngine):
             fileobj=fileobj,
             path=path,
             labels=labels,
+            platform="linux/amd64",
             **kwargs,
         )
 


### PR DESCRIPTION
our base-env setup assumes amd64, so avoid platform issues on e.g. ARM macs. We should be explicit in telling the builder that it _must_ be amd64.

I believe this closes #1174 (it works for me, though I had to clean out image caches to resolve errors)