### PR TITLE
get CI working again

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   docker:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build-n-publish:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -107,11 +107,9 @@ jobs:
           pip install --upgrade -r dev-requirements.txt
           python setup.py bdist_wheel
           pip install dist/*.whl
+          # add for mercurial tests
+          pip install mercurial hg-evolve
           pip freeze
-          # hg-evolve pinned to 9.2 because hg-evolve dropped support for
-          # hg 4.5, installed with apt in Ubuntu 18.04
-          $(hg debuginstall --template "{pythonexe}") -m pip install setuptools --user
-          $(hg debuginstall --template "{pythonexe}") -m pip install hg-evolve==9.2 --user
 
       - name: "Run tests"
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ env:
 jobs:
   # Job to run linter / autoformat
   lint:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       # Action Repo: https://github.com/actions/checkout
       - name: "Checkout repo"
@@ -62,7 +62,7 @@ jobs:
     # Previous job must have successfully completed for this job to execute
     # - https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idneeds
     needs: lint
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     # - https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstrategy
     strategy:
       fail-fast: false  # Do not cancel all jobs if one fails

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN pip3 install hg-evolve --user --no-cache-dir
 
 # install repo2docker
 COPY --from=0 /tmp/wheelhouse /tmp/wheelhouse
-RUN pip3 install --no-cache-dir /tmp/wheelhouse/*.whl \
+RUN pip3 install --no-cache-dir --ignore-installed --no-deps /tmp/wheelhouse/*.whl \
  && pip3 list
 
 # add git-credential helper


### PR DESCRIPTION
Started as one fix, but now it's a couple:

- Avoid redundant resolution in Dockerfile pip install

  avoids error attempting to 'upgrade' a package installed by apk (a dependency of mercurial, perhaps), which pip refuses.

  Since dependencies are resolved already, adding `--ignore-installed --no-deps` just installs all the wheels as-is, skipping the redundant solve (already done in `pip wheel`) and upgrade.
- Update GHA runners to 20.04, since 18.04 is shutting down. This, in turn, changes how mercurial is installed to be a simple pip install, since `hg` is using Python 2.