### PR TITLE
mount wheels from build stage instead of copying them

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,21 @@
+# syntax = docker/dockerfile:1.3
 ARG ALPINE_VERSION=3.15.0
-FROM alpine:${ALPINE_VERSION}
+FROM alpine:${ALPINE_VERSION} AS builder
 
 RUN apk add --no-cache git python3 python3-dev py-pip build-base
+
+# set pip's cache directory using this environment variable, and use
+# ARG instead of ENV to ensure its only set when the image is built
+ARG PIP_CACHE_DIR=/tmp/pip-cache
 
 # build wheels in first image
 ADD . /tmp/src
 RUN cd /tmp/src && git clean -xfd && git status
-RUN mkdir /tmp/wheelhouse \
+RUN --mount=type=cache,target=${PIP_CACHE_DIR} \
+    mkdir /tmp/wheelhouse \
  && cd /tmp/wheelhouse \
  && pip3 install wheel \
- && pip3 wheel --no-cache-dir /tmp/src \
+ && pip3 wheel /tmp/src \
  && ls -l /tmp/wheelhouse
 
 FROM alpine:${ALPINE_VERSION}
@@ -17,12 +23,17 @@ FROM alpine:${ALPINE_VERSION}
 # install python, git, bash, mercurial
 RUN apk add --no-cache git git-lfs python3 py-pip bash docker mercurial
 
-# install hg-evolve (Mercurial extensions)
-RUN pip3 install hg-evolve --user --no-cache-dir
+# repeat ARG from above
+ARG PIP_CACHE_DIR=/tmp/pip-cache
 
 # install repo2docker
-COPY --from=0 /tmp/wheelhouse /tmp/wheelhouse
-RUN pip3 install --no-cache-dir --ignore-installed --no-deps /tmp/wheelhouse/*.whl \
+# and hg-evolve (Mercurial extensions)
+# mount /tmp/wheelhouse from build stage
+# avoids extra layer when using COPY --from
+RUN --mount=type=cache,target=${PIP_CACHE_DIR} \
+    --mount=type=cache,from=builder,source=/tmp/wheelhouse,target=/tmp/wheelhouse \
+    pip3 install --ignore-installed --no-deps /tmp/wheelhouse/*.whl \
+ && pip3 install hg-evolve \
  && pip3 list
 
 # add git-credential helper


### PR DESCRIPTION
avoids extra layer of unused wheel files

use mounted pip cache instead of disabling cache - all the benefits of no cache (size), and all the benefits of cache (local rebuild time).

I think we should consider enabling cache mounts instead of `--no-cache-dir` in repo2docker builds themselves, but that means requiring buildkit, which affects users. Requiring buildkit in our own image doesn't affect users at all.

see also : https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/2856