### PR TITLE
fail on unsupported Python

### DIFF
--- a/repo2docker/buildpacks/conda/__init__.py
+++ b/repo2docker/buildpacks/conda/__init__.py
@@ -163,7 +163,7 @@ class CondaBuildPack(BaseImage):
         frozen_name = "environment.lock"
         pip_frozen_name = "requirements.txt"
         if py_version:
-            if self.py2:
+            if self.python_version == "2.7":
                 # python 2 goes in a different env
                 files[
                     "conda/environment.py-2.7.lock"
@@ -180,8 +180,8 @@ class CondaBuildPack(BaseImage):
                 if os.path.exists(os.path.join(HERE, py_frozen_name)):
                     frozen_name = py_frozen_name
                     pip_frozen_name = f"requirements.py-{py_version}.pip"
-                if not frozen_name:
-                    self.log.warning(f"No frozen env for {py_version}\n")
+                else:
+                    raise ValueError(f"Python version {py_version} is not supported!")
         files[
             "conda/" + frozen_name
         ] = self._nb_environment_file = "/tmp/env/environment.lock"

--- a/tests/unit/test_buildpack.py
+++ b/tests/unit/test_buildpack.py
@@ -2,7 +2,7 @@ from os.path import join as pjoin
 
 import pytest
 from tempfile import TemporaryDirectory
-from repo2docker.buildpacks import LegacyBinderDockerBuildPack
+from repo2docker.buildpacks import LegacyBinderDockerBuildPack, PythonBuildPack
 from repo2docker.utils import chdir
 
 
@@ -35,3 +35,13 @@ def test_legacy_on_repo_without_dockerfile():
         with chdir(repodir):
             bp = LegacyBinderDockerBuildPack()
             assert not bp.detect()
+
+
+@pytest.mark.parametrize("python_version", ["2.6", "3.0", "4.10", "3.99"])
+def test_unsupported_python(tmpdir, python_version):
+    tmpdir.chdir()
+    bp = PythonBuildPack()
+    bp._python_version = python_version
+    assert bp.python_version == python_version
+    with pytest.raises(ValueError):
+        bp.render()


### PR DESCRIPTION
rather than warning (which users usually won't notice) and building with the wrong version of Python

closes #1183 (also closes #552 which is the same)


I think this was originally a warning because at some point we had a second step to explicitly install the requested Python version _after_ setting up the base env, so it still _could_ work, but without a fully frozen env. Then that step could potentially fail informatively if e.g. the requested Python didn't exist. But we don't do that anymore (if we ever did, I don't trust my memory), so failing seems better than the current behavior of just using the default Python instead.