### PR TITLE
Use enum to standardise `phase`

### DIFF
--- a/repo2docker/__main__.py
+++ b/repo2docker/__main__.py
@@ -5,7 +5,11 @@ import logging
 from .app import Repo2Docker
 from .engine import BuildError, ImageLoadError
 from . import __version__
-from .utils import validate_and_generate_port_mapping, is_valid_docker_image_name
+from .utils import (
+    validate_and_generate_port_mapping,
+    is_valid_docker_image_name,
+    R2dState,
+)
 
 
 def validate_image_name(image_name):
@@ -302,7 +306,7 @@ def make_r2d(argv=None):
             r2d.log.error(
                 'Cannot mount "{}" in editable mode '
                 "as it is not a directory".format(args.repo),
-                extra=dict(phase="failed"),
+                extra=dict(phase=R2dState.FAILED),
             )
             sys.exit(1)
 

--- a/repo2docker/contentproviders/git.py
+++ b/repo2docker/contentproviders/git.py
@@ -1,7 +1,7 @@
 import subprocess
 
 from .base import ContentProvider, ContentProviderException
-from ..utils import execute_cmd, check_ref
+from ..utils import execute_cmd, check_ref, R2dState
 
 
 class Git(ContentProvider):
@@ -44,7 +44,7 @@ class Git(ContentProvider):
             hash = check_ref(ref, output_dir)
             if hash is None:
                 self.log.error(
-                    "Failed to check out ref %s", ref, extra=dict(phase="failed")
+                    "Failed to check out ref %s", ref, extra=dict(phase=R2dState.FAILED)
                 )
                 if ref == "master":
                     msg = (

--- a/repo2docker/contentproviders/mercurial.py
+++ b/repo2docker/contentproviders/mercurial.py
@@ -1,7 +1,7 @@
 import subprocess
 
 from .base import ContentProvider, ContentProviderException
-from ..utils import execute_cmd
+from ..utils import execute_cmd, R2dState
 
 args_enabling_topic = ["--config", "extensions.topic="]
 
@@ -62,7 +62,7 @@ class Mercurial(ContentProvider):
                     yield line
             except subprocess.CalledProcessError:
                 self.log.error(
-                    "Failed to update to ref %s", ref, extra=dict(phase="failed")
+                    "Failed to update to ref %s", ref, extra=dict(phase=R2dState.FAILED)
                 )
                 raise ValueError("Failed to update to ref {}".format(ref))
 

--- a/repo2docker/utils.py
+++ b/repo2docker/utils.py
@@ -1,4 +1,5 @@
 from contextlib import contextmanager
+from enum import Enum
 from functools import partial
 import os
 import re
@@ -8,6 +9,21 @@ import chardet
 from shutil import copystat, copy2
 
 from traitlets import Integer, TraitError
+
+
+class R2dState(Enum):
+    """
+    The current state of repo2docker
+    """
+
+    FETCHING = "fetching"
+    BUILDING = "building"
+    PUSHING = "pushing"
+    RUNNING = "running"
+    FAILED = "failed"
+
+    def __str__(self):
+        return self.value
 
 
 def execute_cmd(cmd, capture=False, **kwargs):


### PR DESCRIPTION
Replace the phase strings used in logs with an Enum.

This is a follow-up to https://github.com/jupyterhub/binderhub/pull/1525#issuecomment-1222036439 and replaces the inconsistent use of `failed`/`failure` with `failed`