### PR TITLE
ci: general refresh of github workflows, update gha versions and let dependabot do it, etc.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+# dependabot.yml reference: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+#
+# Notes:
+# - Status and logs from dependabot are provided at
+#   https://github.com/jupyterhub/repo2docker/network/updates.
+# - YAML anchors are not supported here or in GitHub Workflows.
+#
+version: 2
+updates:
+  # Maintain dependencies in our GitHub Workflows
+  - package-ecosystem: github-actions
+    directory: "/" # This should be / rather than .github/workflows
+    schedule:
+      interval: weekly
+      time: "05:00"
+      timezone: "Etc/UTC"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -27,7 +27,7 @@ on:
 
 jobs:
   docker:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,8 +1,29 @@
+# This is a GitHub workflow defining a set of jobs with a set of steps.
+# ref: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions
+#
 name: Docker build
 
 on:
-  - push
-  - pull_request
+  pull_request:
+    paths-ignore:
+      - "docs/**"
+      - "**.md"
+      - "**.rst"
+      - ".github/workflows/*"
+      - "!.github/workflows/docker.yml"
+  push:
+    paths-ignore:
+      - "docs/**"
+      - "**.md"
+      - "**.rst"
+      - ".github/workflows/*"
+      - "!.github/workflows/docker.yml"
+    branches-ignore:
+      - "dependabot/**"
+      - "pre-commit-ci-update-config"
+    tags:
+      - "**"
+  workflow_dispatch:
 
 jobs:
   docker:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -30,13 +30,13 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
       # https://github.com/docker/build-push-action
       - name: Build Docker image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           tags: jupyter/repo2docker:pr

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ on:
 
 jobs:
   build-n-publish:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -53,7 +53,7 @@ jobs:
           password: ${{ secrets.PYPI_PASSWORD }}
 
   publish-docker:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       DEFAULT_REGISTRY: quay.io
       IMAGE_NAME: jupyterhub/repo2docker

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,29 @@
+# This is a GitHub workflow defining a set of jobs with a set of steps.
+# ref: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions
+#
 name: Publish
 
 on:
-  push:
   pull_request:
+    paths-ignore:
+      - "docs/**"
+      - "**.md"
+      - "**.rst"
+      - ".github/workflows/*"
+      - "!.github/workflows/release.yml"
+  push:
+    paths-ignore:
+      - "docs/**"
+      - "**.md"
+      - "**.rst"
+      - ".github/workflows/*"
+      - "!.github/workflows/release.yml"
+    branches-ignore:
+      - "dependabot/**"
+      - "pre-commit-ci-update-config"
+    tags:
+      - "**"
+  workflow_dispatch:
 
 jobs:
   build-n-publish:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
-
       - uses: actions/setup-python@v4
         with:
           python-version: "3.8"
@@ -85,7 +84,6 @@ jobs:
       # Setup docker to build for multiple platforms, see:
       # https://github.com/docker/build-push-action/tree/v2.4.0#usage
       # https://github.com/docker/build-push-action/blob/v2.4.0/docs/advanced/multi-platform.md
-
       - name: Set up QEMU (for docker buildx)
         uses: docker/setup-qemu-action@v2
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,10 +29,9 @@ jobs:
   build-n-publish:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - name: "Setup Python 3.8"
-        uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: "3.8"
 
@@ -50,7 +49,7 @@ jobs:
       # all previous steps always run in order to exercise them
       - name: Publish distribution to PyPI
         if: startsWith(github.ref, 'refs/tags')
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@v1.5.1
         with:
           password: ${{ secrets.PYPI_PASSWORD }}
 
@@ -79,7 +78,7 @@ jobs:
           echo "Publishing to $REGISTRY"
 
       # versioneer requires the full git history for non-tags
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -88,10 +87,10 @@ jobs:
       # https://github.com/docker/build-push-action/blob/v2.4.0/docs/advanced/multi-platform.md
 
       - name: Set up QEMU (for docker buildx)
-        uses: docker/setup-qemu-action@25f0500ff22e406f7191a2a8ba8cda16901ca018
+        uses: docker/setup-qemu-action@v2
 
       - name: Set up Docker Buildx (for multi-arch builds)
-        uses: docker/setup-buildx-action@2a4b53665e15ce7d7049afb11ff1f70ff1610609
+        uses: docker/setup-buildx-action@v2
         with:
           # Allows pushing to registry on localhost:5000
           driver-opts: network=host
@@ -118,7 +117,7 @@ jobs:
           echo "TAGS=$TAGS" >> $GITHUB_ENV
 
       - name: Build and push repo2docker
-        uses: docker/build-push-action@e1b7f96249f2e4c8e4ac1519b9608c0d48944a1f
+        uses: docker/build-push-action@v3
         with:
           context: .
           platforms: linux/amd64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,13 +34,12 @@ jobs:
         with:
           python-version: "3.9"
 
-      - name: "Install dependencies"
+      - name: Install dependencies
         run: |
-          pip install --upgrade setuptools pip
-          pip install --upgrade -r dev-requirements.txt
+          pip install -r dev-requirements.txt
           pip freeze
 
-      - name: "Build distribution archives"
+      - name: Build distribution archives
         run: |
           python setup.py sdist bdist_wheel
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.8"
+          python-version: "3.9"
 
       - name: "Install dependencies"
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,21 +43,15 @@ jobs:
   lint:
     runs-on: ubuntu-20.04
     steps:
-      # Action Repo: https://github.com/actions/checkout
-      - name: "Checkout repo"
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
+      - uses: actions/checkout@v3
 
-      # Action Repo: https://github.com/actions/setup-python
-      - name: "Setup Python"
-        uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: "3.8"
 
       # Action Repo: https://github.com/actions/cache
       - name: "Cache pip dependencies"
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('dev-requirements.txt') }}
@@ -100,17 +94,15 @@ jobs:
             repo_type: venv
 
     steps:
-      - name: "Checkout repo"
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - name: "Setup Python"
-        uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python_version }}
+          python-version: "${{ matrix.python_version }}"
 
       # Action Repo: https://github.com/actions/cache
       - name: "Cache pip dependencies"
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('dev-requirements.txt') }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ env:
 
 jobs:
   pre-commit:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -66,11 +66,12 @@ jobs:
 
   test:
     needs: pre-commit
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-${{ matrix.ubuntu_version }}"
 
     strategy:
       fail-fast: false  # Do not cancel all jobs if one fails
       matrix:
+        ubuntu_version: ["22.04"]
         python_version: ["3.8"]
         repo_type:
           - base
@@ -84,7 +85,11 @@ jobs:
           - unit
           - venv
         include:
-          - python_version: "3.6"
+          # The actions/setup-python action with Python version 3.6 isn't
+          # possible to use with the ubuntu-22.04 runner, so we use ubuntu-20.04
+          # for this test where Python 3.6 remain available.
+          - ubuntu_version: "20.04"
+            python_version: "3.6"
             repo_type: venv
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.8"
+          python-version: "3.9"
 
       # There will almost never be a cache hit on the cache key when this job is
       # run, as it is the first of all jobs in this workflow. The subsequent
@@ -72,7 +72,7 @@ jobs:
       fail-fast: false  # Do not cancel all jobs if one fails
       matrix:
         ubuntu_version: ["22.04"]
-        python_version: ["3.8"]
+        python_version: ["3.9"]
         repo_type:
           - base
           - conda

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,10 +62,9 @@ jobs:
           path: ~/.cache/pip
           key: "${{ github.run_id }}-${{ matrix.python_version }}"
 
-      - name: "Install dependencies"
+      - name: Install dependencies
         run: |
-          pip install --upgrade setuptools pip
-          pip install --upgrade -r dev-requirements.txt
+          pip install -r dev-requirements.txt
           pip freeze
 
       - run: pre-commit run --all-files
@@ -110,22 +109,27 @@ jobs:
           path: ~/.cache/pip
           key: "${{ github.run_id }}-${{ matrix.python_version }}"
 
-      - name: "Install"
+      - name: Install dependencies
         run: |
-          pip install --upgrade setuptools pip wheel
-          pip install --upgrade -r dev-requirements.txt
-          python setup.py bdist_wheel
-          pip install dist/*.whl
-          # add for mercurial tests
-          pip install mercurial hg-evolve
+          pip install -r dev-requirements.txt
           pip freeze
 
-      - name: "Run tests"
+      - name: Install repo2docker
+        run: |
+          python setup.py bdist_wheel
+          pip install dist/*.whl
+
+          # add for mercurial tests
+          pip install mercurial hg-evolve
+
+          pip freeze
+
+      - name: Run tests
         run: |
           cd tests
           pytest --verbose --color=yes --durations=10 --cov=repo2docker ./${{ matrix.repo_type }}
 
-      - name: "Upload code coverage stats"
+      - name: Upload code coverage stats
         run: |
           pip install codecov
           pushd tests && codecov && cat

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,14 +49,14 @@ jobs:
         with:
           python-version: "3.8"
 
-      # Action Repo: https://github.com/actions/cache
-      - name: "Cache pip dependencies"
+      # There will almost never be a cache hit on the cache key when this job is
+      # run, as it is the first of all jobs in this workflow. The subsequent
+      # jobs in this workflow can rely on this cache though.
+      - name: Save pip's install cache on job completion
         uses: actions/cache@v3
         with:
           path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('dev-requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
+          key: "${{ github.run_id }}"
 
       - name: "Install dependencies"
         run: |
@@ -100,14 +100,11 @@ jobs:
         with:
           python-version: "${{ matrix.python_version }}"
 
-      # Action Repo: https://github.com/actions/cache
-      - name: "Cache pip dependencies"
+      - name: Restore pip's install cache from previous job
         uses: actions/cache@v3
         with:
           path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('dev-requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
+          key: "${{ github.run_id }}"
 
       - name: "Install"
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,7 +71,7 @@ jobs:
 
   test:
     needs: pre-commit
-    runs-on: ubuntu-${{ matrix.ubuntu_version }}"
+    runs-on: ubuntu-${{ matrix.ubuntu_version }}
 
     strategy:
       fail-fast: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -124,13 +124,10 @@ jobs:
 
           pip freeze
 
-      - name: Run tests
+      - name: Run pytest
         run: |
-          cd tests
-          pytest --verbose --color=yes --durations=10 --cov=repo2docker ./${{ matrix.repo_type }}
+          pytest --verbose --color=yes --durations=10 --cov=repo2docker tests/${{ matrix.repo_type }}
 
-      - name: Upload code coverage stats
+      - name: Submit codecov report
         run: |
-          pip install codecov
-          pushd tests && codecov && cat
-          cat /home/runner/work/repo2docker/repo2docker/tests/coverage.xml
+          codecov

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,12 +39,10 @@ env:
   GIT_AUTHOR_NAME: CI User
 
 jobs:
-  # Job to run linter / autoformat
-  lint:
+  pre-commit:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
-
       - uses: actions/setup-python@v4
         with:
           python-version: "3.8"
@@ -64,16 +62,12 @@ jobs:
           pip install --upgrade -r dev-requirements.txt
           pip freeze
 
-      - name: "Run linter"
-        run: |
-          pre-commit run --all-files
+      - run: pre-commit run --all-files
 
   test:
-    # Previous job must have successfully completed for this job to execute
-    # - https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idneeds
-    needs: lint
+    needs: pre-commit
     runs-on: ubuntu-20.04
-    # - https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstrategy
+
     strategy:
       fail-fast: false  # Do not cancel all jobs if one fails
       matrix:
@@ -95,7 +89,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-
       - uses: actions/setup-python@v4
         with:
           python-version: "${{ matrix.python_version }}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,11 +41,17 @@ env:
 jobs:
   pre-commit:
     runs-on: ubuntu-22.04
+
+    strategy:
+      fail-fast: false
+      matrix:
+        python_version: ["3.9"]
+
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.9"
+          python-version: "${{ matrix.python_version }}"
 
       # There will almost never be a cache hit on the cache key when this job is
       # run, as it is the first of all jobs in this workflow. The subsequent
@@ -54,7 +60,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.cache/pip
-          key: "${{ github.run_id }}"
+          key: "${{ github.run_id }}-${{ matrix.python_version }}"
 
       - name: "Install dependencies"
         run: |
@@ -69,7 +75,7 @@ jobs:
     runs-on: ubuntu-${{ matrix.ubuntu_version }}"
 
     strategy:
-      fail-fast: false  # Do not cancel all jobs if one fails
+      fail-fast: false
       matrix:
         ubuntu_version: ["22.04"]
         python_version: ["3.9"]
@@ -102,7 +108,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.cache/pip
-          key: "${{ github.run_id }}"
+          key: "${{ github.run_id }}-${{ matrix.python_version }}"
 
       - name: "Install"
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -123,7 +123,7 @@ jobs:
       - name: "Run tests"
         run: |
           cd tests
-          pytest --durations 10 --cov repo2docker -v ${{ matrix.repo_type }}
+          pytest --verbose --color=yes --durations=10 --cov=repo2docker ./${{ matrix.repo_type }}
 
       - name: "Upload code coverage stats"
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,19 +1,35 @@
-# Useful GitHub Actions docs:
+# This is a GitHub workflow defining a set of jobs with a set of steps.
+# ref: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions
 #
-# - https://help.github.com/en/actions
-# - https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions
-# - https://help.github.com/en/actions/configuring-and-managing-workflows/configuring-a-workflow
-# - https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions
-
-name: Continuous Integration
+name: Test
 
 on:
-  push:
   pull_request:
+    paths-ignore:
+      - "docs/**"
+      - "**.md"
+      - "**.rst"
+      - ".github/workflows/*"
+      - "!.github/workflows/test.yml"
+  push:
+    paths-ignore:
+      - "docs/**"
+      - "**.md"
+      - "**.rst"
+      - ".github/workflows/*"
+      - "!.github/workflows/test.yml"
+    branches-ignore:
+      - "dependabot/**"
+      - "pre-commit-ci-update-config"
+    tags:
+      - "**"
   schedule:
-    # Weekly test so we know if tests break for external reasons
-    # https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#scheduled-events
+    # Run weekly test so we know if tests break for external reasons
+    # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#scheduled-events
+    #
+    # At 10:36 on Sunday (https://crontab.guru)
     - cron: '36 10 * * 0'
+  workflow_dispatch:
 
 # Global environment variables
 env:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,44 @@
+# pre-commit is a tool to perform a predefined set of tasks manually and/or
+# automatically before git commits are made.
+#
+# Config reference: https://pre-commit.com/#pre-commit-configyaml---top-level
+#
+# Common tasks
+#
+# - Run on all files:   pre-commit run --all-files
+# - Register git hooks: pre-commit install --install-hooks
+#
 repos:
-- repo: https://github.com/ambv/black
-  rev: 22.3.0
-  hooks:
-  - id: black
-    args: [--target-version=py36]
+  # # Autoformat: Python code, syntax patterns are modernized
+  # - repo: https://github.com/asottile/pyupgrade
+  #   rev: v3.0.0
+  #   hooks:
+  #     - id: pyupgrade
+  #       args:
+  #         - --py38-plus
+
+  # Autoformat: Python code
+  - repo: https://github.com/psf/black
+    rev: 22.10.0
+    hooks:
+      - id: black
+        args:
+          - --target-version=py36
+          - --target-version=py37
+          - --target-version=py38
+          - --target-version=py39
+          - --target-version=py310
+
+  # # Autoformat: Python code
+  # - repo: https://github.com/pycqa/isort
+  #   rev: 5.10.1
+  #   hooks:
+  #     - id: isort
+  #       args:
+  #         - --profile=black
+
+  # # Autoformat: markdown, yaml (but not helm templates)
+  # - repo: https://github.com/pre-commit/mirrors-prettier
+  #   rev: v2.7.1
+  #   hooks:
+  #     - id: prettier

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # <a href="https://github.com/jupyterhub/repo2docker"><img src="https://raw.githubusercontent.com/jupyterhub/repo2docker/8731ecf0967cc5fde028c456f2b92be651ebbc18/docs/source/_static/images/repo2docker.png" height="48px" /> repo2docker</a>
 
-[![Build Status](https://github.com/jupyterhub/repo2docker/workflows/Continuous%20Integration/badge.svg)](https://github.com/jupyterhub/repo2docker/actions)
+[![Build Status](https://github.com/jupyterhub/repo2docker/workflows/Test/badge.svg)](https://github.com/jupyterhub/repo2docker/actions)
 [![Documentation Status](https://readthedocs.org/projects/repo2docker/badge/?version=latest)](http://repo2docker.readthedocs.io/en/latest/?badge=latest)
 [![Contribute](https://img.shields.io/badge/I_want_to_contribute!-grey?logo=jupyter)](https://repo2docker.readthedocs.io/en/latest/contributing/contributing.html)
 [![Docker Repository on Quay](https://img.shields.io/badge/quay.io-container-green "Docker Repository on Quay")](https://quay.io/repository/jupyterhub/repo2docker?tab=tags)

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,4 @@
+codecov
 conda-lock
 pre-commit
 pytest-cov

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,7 +1,7 @@
-pyyaml
-pytest>=4.6
-wheel
-pytest-cov
-pre-commit
-requests_mock
 conda-lock
+pre-commit
+pytest-cov
+pytest>=4.6
+pyyaml
+requests_mock
+wheel


### PR DESCRIPTION
Just passing by trying to keep this repo up to date with various practices across the JupyterHub organization, fixing details such as ensuring the use of a pip cache is robust.

This should not have any influence on the actual function of repo2docker, just the CI system.