### PR TITLE
Remove conda buildpacks pin of r-irkernel to 1.2

### DIFF
--- a/repo2docker/buildpacks/conda/__init__.py
+++ b/repo2docker/buildpacks/conda/__init__.py
@@ -362,7 +362,7 @@ class CondaBuildPack(BaseImage):
                 (
                     "${NB_USER}",
                     r"""
-                ${{MAMBA_EXE}} install -p {0} r-base{1} r-irkernel=1.2 r-devtools -y && \
+                ${{MAMBA_EXE}} install -p {0} r-base{1} r-irkernel r-devtools -y && \
                 ${{MAMBA_EXE}} clean --all -f -y && \
                 ${{MAMBA_EXE}} list -p {0}
                 """.format(
@@ -385,7 +385,7 @@ class CondaBuildPack(BaseImage):
                 ),
                 (
                     "${NB_USER}",
-                    # Install a pinned version of IRKernel and set it up for use!
+                    # Register the jupyter kernel
                     r"""
                  R --quiet -e "IRkernel::installspec(prefix='{0}')"
                  """.format(


### PR DESCRIPTION
If r-base is pinned, r-irkernel will resolve to a version that is compatible with it. But if we pin r-irkernel and not r-base, the opposite will happen and we will end up with an older version of r-base than is supported by r-irkernel's modern versions.

I find debugging how versions resolve with conda is really tricky, so unless we have clear principles of what the pin should be and why, I strongly advocate we don't have it pinned here.

In this case, having r-irkernel pinned to 1.2 caused us the conda buildpack to get stuck at R version 4.1 instead of going to R 4.2 that is now available. Using a runtime.txt without R pinned will result in 4.2 though, but the conda buildpack is stuck at 4.1 without this.

## Related

- A test to catch this is available in #1188. If this is merged, we can remove a commit about this from there and it can be made a ci only PR
- The R buildpack defaults to 4.2 as of #1188