### PR TITLE
Create wheels with the build package, stop calling setup.py directly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,13 @@ jobs:
           python -m build --sdist --wheel .
           ls -l dist
 
+      # ref: https://github.com/actions/upload-artifact#readme
+      - uses: actions/upload-artifact@v3
+        with:
+          name: repo2docker_service-${{ github.sha }}
+          path: "dist/*"
+          if-no-files-found: error
+
       # This step is only run when a new tag is pushed
       # all previous steps always run in order to exercise them
       - name: Publish distribution to PyPI

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,14 +34,15 @@ jobs:
         with:
           python-version: "3.9"
 
-      - name: Install dependencies
+      - name: install build requirements
         run: |
-          pip install -r dev-requirements.txt
+          pip install build
           pip freeze
 
-      - name: Build distribution archives
+      - name: build release
         run: |
-          python setup.py sdist bdist_wheel
+          python -m build --sdist --wheel .
+          ls -l dist
 
       # This step is only run when a new tag is pushed
       # all previous steps always run in order to exercise them

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
       # ref: https://github.com/actions/upload-artifact#readme
       - uses: actions/upload-artifact@v3
         with:
-          name: repo2docker_service-${{ github.sha }}
+          name: repo2docker-${{ github.sha }}
           path: "dist/*"
           if-no-files-found: error
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -116,7 +116,7 @@ jobs:
 
       - name: Install repo2docker
         run: |
-          python setup.py bdist_wheel
+          python -m build --wheel .
           pip install dist/*.whl
 
           # add for mercurial tests

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,4 @@
+build
 codecov
 conda-lock
 pre-commit
@@ -5,4 +6,3 @@ pytest-cov
 pytest>=4.6
 pyyaml
 requests_mock
-wheel


### PR DESCRIPTION
I understand it as using setup.py directly is being phased out in favor of using for example `build` that I think can handle building wheels for packages with `setup.py` or `pyproject.toml`.