### PR TITLE
ci: stop running pre-commit in gha, rely on pre-commit.ci

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,47 +39,7 @@ env:
   GIT_AUTHOR_NAME: CI User
 
 jobs:
-  populate-pip-cache:
-    runs-on: ubuntu-22.04
-
-    strategy:
-      fail-fast: false
-      matrix:
-        python_version: ["3.9"]
-
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-        with:
-          python-version: "${{ matrix.python_version }}"
-
-      # There will almost never be a cache hit on the cache key when this job is
-      # run, as it is the first of all jobs in this workflow. The subsequent
-      # jobs in this workflow can rely on this cache though.
-      - name: Save pip's install cache on job completion
-        uses: actions/cache@v3
-        with:
-          path: ~/.cache/pip
-          key: "${{ github.run_id }}-${{ matrix.python_version }}"
-
-      - name: Install dependencies
-        run: |
-          pip install -r dev-requirements.txt
-
-          # add for mercurial tests
-          pip install mercurial hg-evolve
-
-          pip freeze
-
-      - name: Install repo2docker
-        run: |
-          python -m build --wheel .
-          pip install dist/*.whl
-
-          pip freeze
-
   test:
-    needs: populate-pip-cache
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
 
     strategy:
@@ -111,12 +71,6 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: "${{ matrix.python_version }}"
-
-      - name: Restore pip's install cache from previous job
-        uses: actions/cache@v3
-        with:
-          path: ~/.cache/pip
-          key: "${{ github.run_id }}-${{ matrix.python_version }}"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ env:
   GIT_AUTHOR_NAME: CI User
 
 jobs:
-  pre-commit:
+  populate-pip-cache:
     runs-on: ubuntu-22.04
 
     strategy:
@@ -65,12 +65,21 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -r dev-requirements.txt
+
+          # add for mercurial tests
+          pip install mercurial hg-evolve
+
           pip freeze
 
-      - run: pre-commit run --all-files
+      - name: Install repo2docker
+        run: |
+          python -m build --wheel .
+          pip install dist/*.whl
+
+          pip freeze
 
   test:
-    needs: pre-commit
+    needs: populate-pip-cache
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
 
     strategy:


### PR DESCRIPTION
I've activate pre-commit.ci to run against this github repo already and it works. This PR updates the pre-commit job that also acted as a job populating a pip cache as just a job that populates the pip cache, and does so a bit more completely.

This PR includes #1199 that introduced the `build` package into dev-requirements.txt.