### PR TITLE
ci: add workaround to breaking git security change in test suite

### DIFF
--- a/repo2docker/contentproviders/git.py
+++ b/repo2docker/contentproviders/git.py
@@ -65,8 +65,25 @@ class Git(ContentProvider):
                 yield line
 
         # ensure that git submodules are initialised and updated
+        #
+        # WARNING: To pass `-c protocol.file.allow=always` is a workaround to a
+        #          security patch and can have real implications, we must
+        #          evaluate if we can do this or if we can handle this another
+        #          way instead.
+        #
+        #          https://github.com/jupyterhub/repo2docker/issues/1198#issuecomment-1288114992
+        #          https://bugs.launchpad.net/ubuntu/+source/git/+bug/1993586
+        #
         for line in execute_cmd(
-            ["git", "submodule", "update", "--init", "--recursive"],
+            [
+                "git",
+                "-c",
+                "protocol.file.allow=always",
+                "submodule",
+                "update",
+                "--init",
+                "--recursive",
+            ],
             cwd=output_dir,
             capture=yield_output,
         ):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -152,8 +152,24 @@ def repo_with_submodule():
         subprocess.check_call(
             ["git", "checkout", "-b", "branch-with-submod"], cwd=git_a_dir
         )
+        # NOTE: -c protocol.file.allow=always was added as a quick workaround
+        #       with possible security impacts. Since this is a test suite, its
+        #       naively assumed to be acceptable.
+        #
+        #       https://github.com/jupyterhub/repo2docker/issues/1198#issuecomment-1288114992
+        #       https://bugs.launchpad.net/ubuntu/+source/git/+bug/1993586/comments/3
+        #
         subprocess.check_call(
-            ["git", "submodule", "add", git_b_dir, "submod"], cwd=git_a_dir
+            [
+                "git",
+                "-c",
+                "protocol.file.allow=always",
+                "submodule",
+                "add",
+                git_b_dir,
+                "submod",
+            ],
+            cwd=git_a_dir,
         )
         # checkout the first commit for the submod, not the latest
         subprocess.check_call(


### PR DESCRIPTION
Closes #1198 by adding `"-c protocol.file.allow=always"` to a `git submodule add` command run in a test fixture. Since `repo2docker` itself isn't modified, I'm presuming this can be acceptable even though I don't grasp the details here.