### PR TITLE
Adjust to git security restrictions in test suite

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -134,6 +134,25 @@ def repo_with_submodule():
     the submodule yet.
 
     """
+    # This fixture relies on "git submodule" referencing local submodules, but
+    # that is considered unsafe and must be explicitly allowed. To run this
+    # test, it must be explicitly allowed. In CI environment this is
+    # automatically configured.
+    #
+    # https://github.com/jupyterhub/repo2docker/issues/1198#issuecomment-1288128616
+    #
+    if os.environ.get("CI"):
+        subprocess.check_call(
+            ["git", "config", "--global", "--add", "protocol.file.allow", "always"]
+        )
+    else:
+        try:
+            subprocess.check_call(
+                ["git", "config", "--get", "protocol.file.allow", "always"]
+            )
+        except subprocess.SubprocessError:
+            pytest.skip("unsupported git configuration")
+
     with TemporaryDirectory() as git_a_dir, TemporaryDirectory() as git_b_dir:
         # create "parent" repository
         subprocess.check_call(["git", "init"], cwd=git_a_dir)


### PR DESCRIPTION
Closes #1198 by not making any change to repo2docker's behavior, but the test suite.

I had some wishes in how this was resolved and is very happy about the resolutions.

- **Wish:** to avoid adding pre-requisite setup steps to our CI environment that runs `pytest`
  **Resolution:** to conditionally set the required `git config` if a `CI` environment variable is detected.
  
- **Wish:** to not make `pytest` run locally fail.
  **Resolution:** to conditionally skip this test if the relevant `git config` wasn't detected.

Before coming up with this strategy, I tried a few others that failed (adding git config to a specific git repository, trying to manipulate git to detect a temporary config file).

This was discussed in https://github.com/orgs/jupyterhub/teams/jupyterhubteam/discussions/10, thank you @manics for your input!!!! :heart: :tada: :sunflower: