### PR TITLE
run submodule test over https

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -121,7 +121,7 @@ def repo_with_content(git_repo):
     yield git_repo, sha1
 
 
-@pytest.fixture()
+@pytest.fixture
 def repo_with_submodule():
     """Create a git repository with a git submodule in a non-master branch.
 
@@ -134,15 +134,13 @@ def repo_with_submodule():
     the submodule yet.
 
     """
-    with TemporaryDirectory() as git_a_dir, TemporaryDirectory() as git_b_dir:
+    submodule_repo = "https://github.com/binderhub-ci-repos/requirements"
+    submod_sha1_b = "20c4fe55a9b2c5011d228545e821b1c7b1723652"
+
+    with TemporaryDirectory() as git_a_dir:
         # create "parent" repository
         subprocess.check_call(["git", "init"], cwd=git_a_dir)
         _add_content_to_git(git_a_dir)
-        # create repository with 2 commits that will be the submodule
-        subprocess.check_call(["git", "init"], cwd=git_b_dir)
-        _add_content_to_git(git_b_dir)
-        submod_sha1_b = _get_sha1(git_b_dir)
-        _add_content_to_git(git_b_dir)
 
         # create a new branch in the parent without any submodule
         subprocess.check_call(
@@ -153,7 +151,14 @@ def repo_with_submodule():
             ["git", "checkout", "-b", "branch-with-submod"], cwd=git_a_dir
         )
         subprocess.check_call(
-            ["git", "submodule", "add", git_b_dir, "submod"], cwd=git_a_dir
+            [
+                "git",
+                "submodule",
+                "add",
+                submodule_repo,
+                "submod",
+            ],
+            cwd=git_a_dir,
         )
         # checkout the first commit for the submod, not the latest
         subprocess.check_call(

--- a/tests/unit/contentproviders/test_git.py
+++ b/tests/unit/contentproviders/test_git.py
@@ -33,7 +33,7 @@ def test_submodule_clone(repo_with_submodule):
             pass
 
         assert os.path.exists(os.path.join(clone_dir2, "test"))
-        assert not os.path.exists(os.path.join(submod_dir, "test"))
+        assert not os.path.exists(os.path.join(submod_dir, "requirements.txt"))
 
     with TemporaryDirectory() as clone_dir:
         submod_dir = os.path.join(clone_dir, "submod")  # set by fixture
@@ -42,7 +42,7 @@ def test_submodule_clone(repo_with_submodule):
         for _ in git_content.fetch(spec, clone_dir):
             pass
         assert os.path.exists(os.path.join(clone_dir, "test"))
-        assert os.path.exists(os.path.join(submod_dir, "test"))
+        assert os.path.exists(os.path.join(submod_dir, "requirements.txt"))
 
         # get current sha1 of submodule
         cmd = ["git", "rev-parse", "HEAD"]


### PR DESCRIPTION
avoids assertion with file-based submodules, without any changes to git config by using one of the safe submodule transports.

alternative to #1203 

benefit of #1203: fully local, doesn't rely on external repo (we have lots of tests that do, so I'm not sure this is a big benefit)
benefit of this one: doesn't rely on non-default git config, more realistic to actual submodule use

closes #1198