### PR TITLE
pipfile: pass --clear flag, and do it separetely to not be ignored

### DIFF
--- a/repo2docker/buildpacks/pipfile/__init__.py
+++ b/repo2docker/buildpacks/pipfile/__init__.py
@@ -154,7 +154,8 @@ class PipfileBuildPack(CondaBuildPack):
                 "${NB_USER}",
                 """(cd {working_directory} && \\
                     PATH="${{KERNEL_PYTHON_PREFIX}}/bin:$PATH" \\
-                        pipenv install {install_option} --system --dev \\
+                        pipenv install {install_option} --system --dev && \\
+                        pipenv --clear \\
                 )""".format(
                     working_directory=working_directory,
                     install_option="--ignore-pipfile"


### PR DESCRIPTION
When `pipenv install` is run, it emits various cache files. Ideally, they would be cleaned up. In #1126 @minrk added the `--clear` flag to the `pipenv install` statement, but that didn't seem to work properly.

I made some code inspection and concluded it seems like `--clear` is bypassed when used with `pipenv install`. I consider this a bug in `pipenv`. I didn't find issues about it, and I didn't report it as I'm not certain if its fixed in their latest versions or not and wanted to focus on repo2docker maintenance now.

Closes #1207 and enables #1126 to not include a somewhat unrelated PR/commit.

This PR has been tested to have the desired effect in #1126.