### PR TITLE
ci: use non-deprecated codecov uploader

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,6 +91,4 @@ jobs:
         run: |
           pytest --verbose --color=yes --durations=10 --cov=repo2docker tests/${{ matrix.repo_type }}
 
-      - name: Submit codecov report
-        run: |
-          codecov
+      - uses: codecov/codecov-action@v3

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,4 @@
 build
-codecov
 conda-lock
 pre-commit
 pytest-cov


### PR DESCRIPTION
The python based CLI `codecov` is deprecated, and is maybe what has caused intermittent but often occuring codecov issues recently. They now recommend use of a binary that is also available by using a github action as we will go ahead and do here.

![image](https://user-images.githubusercontent.com/3837114/199082919-1aeea3b4-4db1-40ad-af04-a62df12344dd.png)
