### PR TITLE
Quick-fix for Docker image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,16 @@
 # syntax = docker/dockerfile:1.3
 ARG ALPINE_VERSION=3.16
-FROM alpine:${ALPINE_VERSION} AS builder
+FROM alpine:${ALPINE_VERSION}
 
 RUN apk add --no-cache git python3 python3-dev py-pip build-base
-
-# set pip's cache directory using this environment variable, and use
-# ARG instead of ENV to ensure its only set when the image is built
-ARG PIP_CACHE_DIR=/tmp/pip-cache
 
 # build wheels in first image
 ADD . /tmp/src
 RUN cd /tmp/src && git clean -xfd && git status
-RUN --mount=type=cache,target=${PIP_CACHE_DIR} \
-    mkdir /tmp/wheelhouse \
+RUN mkdir /tmp/wheelhouse \
  && cd /tmp/wheelhouse \
  && pip3 install wheel \
- && pip3 wheel /tmp/src \
+ && pip3 wheel --no-cache-dir /tmp/src \
  && ls -l /tmp/wheelhouse
 
 FROM alpine:${ALPINE_VERSION}
@@ -23,17 +18,12 @@ FROM alpine:${ALPINE_VERSION}
 # install python, git, bash, mercurial
 RUN apk add --no-cache git git-lfs python3 py-pip bash docker mercurial
 
-# repeat ARG from above
-ARG PIP_CACHE_DIR=/tmp/pip-cache
+# install hg-evolve (Mercurial extensions)
+RUN pip3 install hg-evolve --user --no-cache-dir
 
 # install repo2docker
-# and hg-evolve (Mercurial extensions)
-# mount /tmp/wheelhouse from build stage
-# avoids extra layer when using COPY --from
-RUN --mount=type=cache,target=${PIP_CACHE_DIR} \
-    --mount=type=cache,from=builder,source=/tmp/wheelhouse,target=/tmp/wheelhouse \
-    pip3 install --ignore-installed --no-deps /tmp/wheelhouse/*.whl \
- && pip3 install hg-evolve \
+COPY --from=0 /tmp/wheelhouse /tmp/wheelhouse
+RUN pip3 install --no-cache-dir --ignore-installed --no-deps /tmp/wheelhouse/*.whl \
  && pip3 list
 
 # add git-credential helper


### PR DESCRIPTION
The docker image builds are failing on main:
```
#15 4.364 Collecting hg-evolve
#15 4.412   Downloading hg-evolve-10.5.3.tar.gz (847 kB)
#15 4.445      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 847.1/847.1 kB 29.2 MB/s eta 0:00:00
#15 4.621   Preparing metadata (setup.py): started
#15 4.828   Preparing metadata (setup.py): finished with status 'error'
#15 4.835   error: subprocess-exited-with-error
#15 4.835   
#15 4.835   × python setup.py egg_info did not run successfully.
#15 4.835   │ exit code: 1
#15 4.835   ╰─> [1 lines of output]
#15 4.835       ERROR: Can not execute `setup.py` since setuptools is not available in the build environment.
#15 4.835       [end of output]
#15 4.835   
#15 4.835   note: This error originates from a subprocess, and is likely not a problem with pip.
#15 4.838 error: metadata-generation-failed
#15 4.838 
#15 4.838 × Encountered error while generating package metadata.
#15 4.838 ╰─> See above for output.
#15 4.838 
#15 4.838 note: This is an issue with the package mentioned above, not pip.
#15 4.838 hint: See above for details.
#15 ERROR: process "/bin/sh -c pip3 install --ignore-installed --no-deps /tmp/wheelhouse/*.whl  && pip3 install hg-evolve  && pip3 list" did not complete successfully: exit code: 1
```

This is somehow related to `RUN --mount=type=cache,target=${PIP_CACHE_DIR}`, removing it allows the build to succeed. I can't get `RUN --mount=type=cache` to play nicely on my system (the cache isn't always invalidated) so this is a quick fix, but feel free to close this PR and push an alternative fix.


This reverts commit ed82b83ebad77d7c5893e23a73777de4812545dd.
