### PR TITLE
Upgrade to mamba 1.1 and enable rich SAT error messages

### DIFF
--- a/repo2docker/buildpacks/conda/install-base-env.bash
+++ b/repo2docker/buildpacks/conda/install-base-env.bash
@@ -5,7 +5,7 @@ set -ex
 
 cd $(dirname $0)
 
-export MAMBA_VERSION=1.0.0
+export MAMBA_VERSION=1.1.0
 export CONDA_VERSION=4.13.0
 
 URL="https://anaconda.org/conda-forge/micromamba/${MAMBA_VERSION}/download/${CONDA_PLATFORM}/micromamba-${MAMBA_VERSION}-0.tar.bz2"
@@ -34,6 +34,7 @@ channels:
 auto_update_conda: false
 show_channel_urls: true
 update_dependencies: false
+experimental_sat_error_message: true
 # channel_priority: flexible
 EOT
 

--- a/tests/conda/py35-binder-dir/verify
+++ b/tests/conda/py35-binder-dir/verify
@@ -5,12 +5,12 @@ from subprocess import check_output
 assert sys.version_info[:2] == (3, 5), sys.version
 
 out = check_output(["micromamba", "--version"]).decode("utf8").strip()
-assert out == "1.0.0", out
+assert out == "1.1.0", out
 
 out = check_output(["mamba", "--version"]).decode("utf8").strip()
 assert (
     out
-    == """mamba 1.0.0
+    == """mamba 1.1.0
 conda 4.13.0"""
 ), out
 


### PR DESCRIPTION
In this PR, I update mamba to version 1.1, and enable the rich conflict error messages.

For more information about the rich error messages, you can check out the following post:
https://medium.com/@AntoineProuvost/managing-conflicts-with-mamba-6a5fa10ed6a

Old conda error message:
![1_6eDvWxxV6IwMb6EOp5nO-Q](https://user-images.githubusercontent.com/2397974/211737753-24e5ad89-e076-43d0-a800-861841347719.png)

New mamba 1.1 error message:
![1_4FgY6y9QfGLMO3qtim-zSw](https://user-images.githubusercontent.com/2397974/211737769-cab41329-9a5d-4f03-8c83-6f25e8d3409e.png)

We have not seen any issue with this in the past few weeks and plan on removing the "experimental" flag very shortly. 
