### PR TITLE
Also install dev requirements on Gitpod

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,10 +1,12 @@
 tasks:
   - init: |
       pip3 install sphinx-autobuild
+      pip3 install -r dev-requirements.txt
       pip3 install -r docs/requirements.txt
       pip3 install -e .
     command: |
       sphinx-autobuild docs/source/ docs/_build/html/
     name: Sphinx preview
+      
 ports:
   - port: 8000


### PR DESCRIPTION
<!--

Our guide to getting a PR merged https://repo2docker.readthedocs.io/en/latest/contributing/contributing.html#guidelines-to-getting-a-pull-request-merged.

About to propose a big change? Read https://repo2docker.readthedocs.io/en/latest/contributing/contributing.html#process-for-making-a-contribution to maximise the chances of it getting merged quickly.

-->

Gitpod is really convenient for updating packages and running `python freeze.py`. However one has to install the dev dependencies to be able to lock the environments.

This PR automatically installs the dev dependencies on Gitpod so the env is ready on startup.

This also follows the documentation for setting up a dev environment: https://repo2docker.readthedocs.io/en/latest/contributing/contributing.html#set-up-a-local-virtual-environment
