### PR TITLE
Add Conda env library path to RStudio configuration

### DIFF
--- a/repo2docker/buildpacks/conda/__init__.py
+++ b/repo2docker/buildpacks/conda/__init__.py
@@ -396,6 +396,7 @@ class CondaBuildPack(BaseImage):
                     echo auth-none=1 >> /etc/rstudio/rserver.conf && \
                     echo auth-minimum-user-id=0 >> /etc/rstudio/rserver.conf && \
                     echo "rsession-which-r={env_prefix}/bin/R" >> /etc/rstudio/rserver.conf && \
+                    echo "rsession-ld-library-path={env_prefix}/lib" >> /etc/rstudio/rserver.conf && \
                     echo www-frame-origin=same >> /etc/rstudio/rserver.conf
                     """,
                 ),


### PR DESCRIPTION
Currently RStudio packages installed in the environment do not show up in RStudio. The current workaround is to set the `LD_LIBRARY_PATH` environment variable in the `start` file. This change applies a similar fix during the build, adding the proper library path to `rserver.conf`.

Relevant discussion can be found in #1153 and here:

https://discourse.jupyter.org/t/glibcxx-3-4-26-not-found-from-rstudio/7778/5