### PR TITLE
Add optional registry credentials to push()

### DIFF
--- a/repo2docker/docker.py
+++ b/repo2docker/docker.py
@@ -120,6 +120,8 @@ class DockerEngine(ContainerEngine):
         return Image(tags=image["RepoTags"], config=image["ContainerConfig"])
 
     def push(self, image_spec):
+        if self.registry_credentials:
+            self._apiclient.login(**self.registry_credentials)
         return self._apiclient.push(image_spec, stream=True)
 
     def run(


### PR DESCRIPTION
This is to help with setting dynamic registry credentials when pushing in BinderHub

Example using traitlets on the command line:

`repo2docker --push --no-run --image-name docker.io/USERNAME/image:test --ContainerEngine.registry_credentials=registry=docker.io --ContainerEngine.registry_credentials=username=USERNAME --ContainerEngine.registry_credentials=password=PASSWORD https://github.com/binderhub-ci-repos/cached-minimal-dockerfile`

Example using environment variable:
`CONTAINER_ENGINE_REGISTRY_CREDENTIALS='{"registry":"docker.io","username":"USERNAME","password":"PASSWORD"}' repo2docker --push --no-run --image-name docker.io/USERNAME/image:test https://github.com/binderhub-ci-repos/cached-minimal-dockerfile`