### PR TITLE
disable codecov failures

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -6,7 +6,7 @@ coverage:
   status:
     project:
       default:
-        target: auto
+        target: "0%"
     patch:
       default:
-        target: 20%
+        target: "0%"


### PR DESCRIPTION
it's unreliable right now, and we don't want to waste time with incorrect failed status checks

the links in the checks are the main value, not the pass/fail. This matches how it's used in most other jupyterhub repos.
