### PR TITLE
[MRG] download original file formats from Dataverse #1242

### DIFF
--- a/tests/unit/contentproviders/test_dataverse.py
+++ b/tests/unit/contentproviders/test_dataverse.py
@@ -4,8 +4,8 @@ import re
 from io import BytesIO
 from tempfile import TemporaryDirectory
 from unittest.mock import patch
-from urllib.request import Request, urlopen
 from urllib.parse import urlsplit
+from urllib.request import Request, urlopen
 
 import pytest
 

--- a/tests/unit/contentproviders/test_dataverse.py
+++ b/tests/unit/contentproviders/test_dataverse.py
@@ -5,6 +5,7 @@ from io import BytesIO
 from tempfile import TemporaryDirectory
 from unittest.mock import patch
 from urllib.request import Request, urlopen
+from urllib.parse import urlsplit
 
 import pytest
 
@@ -131,7 +132,8 @@ def test_dataverse_fetch(dv_files, requests_mock):
     spec = {"host": harvard_dv, "record": "doi:10.7910/DVN/6ZXAGT"}
 
     def mock_filecontent(req, context):
-        file_no = int(req.url.split("/")[-1]) - 1
+        parts = urlsplit(req.url)
+        file_no = int(parts.path.split("/")[-1]) - 1
         return open(dv_files[file_no], "rb").read()
 
     requests_mock.get(


### PR DESCRIPTION
Dataverse creates plain-text, preservation-friendly copies of certain file formats (some of which are proprietary, such as Stata or SPSS) and this .tab (tab-separated) file is downloaded unless you supply `format=original`, which is what this pull request does.

The original filename (e.g. foo.dta, a Stata file) comes from `originalFileName`, which is only populated when the preservation copy (e.g. foo.tab) has been successfully created.

Additional variables were created to distinguish between `filename`, `original_filename`, and `filename_with_path`. If `original_filename` is available, it's the right one to use.

To allow the tests to continue passing, the query parameters are now removed so just the file id can be cast as an int.

I tested it with a random dataset that has Stata files (.dta):

```
beamish:repo2docker pdurbin$ repo2docker doi:10.7910/DVN/IVLEHB
beamish:repo2docker pdurbin$ 
beamish:repo2docker pdurbin$ docker exec -it inspiring_almeida /bin/bash
pdurbin@521a8dd1e1cc:~$ ls -1
'Codebook for Relational UNFCCC Data.pdf'
country_groups.dta
ENB_relationships.dta
statements_count.dta
unfccc_ratification.dta
'Variable and value labels.xlsx'
pdurbin@521a8dd1e1cc:~$ 
```

Without this fix you get `country_groups.tab` (tab separated), for example.

- Closes #1242