### PR TITLE
dependabot: monthly updates of github actions

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,4 +1,4 @@
-# dependabot.yml reference: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+# dependabot.yaml reference: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 #
 # Notes:
 # - Status and logs from dependabot are provided at

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,9 @@ version: 2
 updates:
   # Maintain dependencies in our GitHub Workflows
   - package-ecosystem: github-actions
-    directory: "/" # This should be / rather than .github/workflows
+    directory: /
+    labels: [ci]
     schedule:
-      interval: weekly
+      interval: monthly
       time: "05:00"
-      timezone: "Etc/UTC"
+      timezone: Etc/UTC


### PR DESCRIPTION
This is one of several PRs opened in the juptyterhub github organization to systematically configure dependabot to update github actions on a monthly basis, for more information see https://github.com/jupyterhub/team-compass/issues/636.