### PR TITLE
missing `f` in julia fetch error f-string

### DIFF
--- a/repo2docker/buildpacks/julia/julia_project.py
+++ b/repo2docker/buildpacks/julia/julia_project.py
@@ -27,7 +27,7 @@ class JuliaProjectTomlBuildPack(PythonBuildPack):
                 "https://julialang-s3.julialang.org/bin/versions.json"
             ).json()
         except Exception as e:
-            raise RuntimeError("Failed to fetch available Julia versions: {e}")
+            raise RuntimeError(f"Failed to fetch available Julia versions: {e}")
         vers = [semver.VersionInfo.parse(v) for v in json.keys()]
         # filter out pre-release versions not supported by find_semver_match()
         filtered_vers = [v for v in vers if v.prerelease is None]


### PR DESCRIPTION
we aren't showing the error, just `{e}`