### PR TITLE
fix github link templates

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -29,9 +29,9 @@ default_role = "literal"
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 templates_path = ["_templates"]
 extlinks = {
-    "issue": ("https://github.com/jupyterhub/repo2docker/issues/%s", "Issue #"),
-    "pr": ("https://github.com/jupyterhub/repo2docker/pull/%s", "PR #"),
-    "user": ("https://github.com/%s", "@"),
+    "issue": ("https://github.com/jupyterhub/repo2docker/issues/%s", "Issue #%s"),
+    "pr": ("https://github.com/jupyterhub/repo2docker/pull/%s", "PR #%s"),
+    "user": ("https://github.com/%s", "@%s"),
 }
 
 


### PR DESCRIPTION
missing `%s` raises error on sphinx 6

closes #1275 