### PR TITLE
Fix links to jupyterlab-demo postBuild file

### DIFF
--- a/docs/source/config_files.rst
+++ b/docs/source/config_files.rst
@@ -162,8 +162,8 @@ Note that by default the build will not be stopped if an error occurs inside a s
 You should include ``set -e`` or the equivalent at the start of the script to avoid errors being silently ignored.
 
 An example use-case of ``postBuild`` file is JupyterLab's demo on mybinder.org.
-It uses a ``postBuild`` file in a folder called ``binder`` to `prepare
-their demo for binder <https://github.com/jupyterlab/jupyterlab-demo/blob/HEAD/binder/postBuild>`_.
+It uses a ``postBuild`` file in a folder called ``.binder`` to `prepare
+their demo for binder <https://github.com/jupyterlab/jupyterlab-demo/blob/HEAD/.binder/postBuild>`_.
 
 
 .. _start:


### PR DESCRIPTION
<!--

Our guide to getting a PR merged https://repo2docker.readthedocs.io/en/latest/contributing/contributing.html#guidelines-to-getting-a-pull-request-merged.

About to propose a big change? Read https://repo2docker.readthedocs.io/en/latest/contributing/contributing.html#process-for-making-a-contribution to maximise the chances of it getting merged quickly.

-->

This fixes the path to jupyterlab-demo binder configuration.