### PR TITLE
Upgrade base image from to Ubuntu 22.04 from 18.04

### DIFF
--- a/docs/source/design.md
+++ b/docs/source/design.md
@@ -49,7 +49,7 @@ Many ingredients go into making an image from a repository:
 
 `repo2docker` controls the first two, the user controls the third one. The current
 policy for the version of the base image is that we will use the current LTS
-version Bionic Beaver (18.04) for the foreseeable future.
+version Jammy Jellyfish (22.04) for the foreseeable future.
 
 The version of `repo2docker` used to build an image can influence which packages
 are installed by default and which features are supported during the build

--- a/docs/source/howto/base_image.md
+++ b/docs/source/howto/base_image.md
@@ -27,7 +27,7 @@ There are **no guarantees that repositories will behave the same way as other re
 For example these are two scenarios that would make your repositories non-reproducible:
 
 - **Your base image is different from `Ubuntu:jammy`.**
-  If you change the base image in a way that is different from repo2docker's default (the Ubuntu `bionic` image), then repositories that **you** build with repo2docker may be significantly different from those that **other** instances of repo2docker build (e.g., those from [`mybinder.org`](https://mybinder.org)).
+  If you change the base image in a way that is different from repo2docker's default (the Ubuntu `jammy` image), then repositories that **you** build with repo2docker may be significantly different from those that **other** instances of repo2docker build (e.g., those from [`mybinder.org`](https://mybinder.org)).
 - **Your base image changes over time.**
   If you choose a base image that changes its composition over time (e.g., an image provided by some other community), then it may cause repositories build with your base image to change in unpredictable ways.
   We recommend choosing a base image that you know to be stable and trustworthy.

--- a/docs/source/howto/base_image.md
+++ b/docs/source/howto/base_image.md
@@ -7,7 +7,7 @@ To do so, use the `base_image` traitlet when invoking `repo2docker`.
 Note that this is not configurable by individual repositories, it is configured when you invoke the `repo2docker` command.
 
 ```{note}
-By default repo2docker builds on top of the `buildpack-deps:bionic` base image, an Ubuntu-based image.
+By default repo2docker builds on top of the `buildpack-deps:jammy` base image, an Ubuntu-based image.
 ```
 
 ## Requirements for your base image
@@ -26,7 +26,7 @@ Changing the base image may have an impact on the reproducibility of repositorie
 There are **no guarantees that repositories will behave the same way as other repo2docker builds if you change the base image**.
 For example these are two scenarios that would make your repositories non-reproducible:
 
-- **Your base image is different from `Ubuntu:bionic`.**
+- **Your base image is different from `Ubuntu:jammy`.**
   If you change the base image in a way that is different from repo2docker's default (the Ubuntu `bionic` image), then repositories that **you** build with repo2docker may be significantly different from those that **other** instances of repo2docker build (e.g., those from [`mybinder.org`](https://mybinder.org)).
 - **Your base image changes over time.**
   If you choose a base image that changes its composition over time (e.g., an image provided by some other community), then it may cause repositories build with your base image to change in unpredictable ways.

--- a/repo2docker/app.py
+++ b/repo2docker/app.py
@@ -448,7 +448,7 @@ class Repo2Docker(Application):
     )
 
     base_image = Unicode(
-        "docker.io/library/buildpack-deps:bionic",
+        "docker.io/library/buildpack-deps:jammy",
         config=True,
         help="""
         Base image to use when building docker images.

--- a/repo2docker/buildpacks/r.py
+++ b/repo2docker/buildpacks/r.py
@@ -217,7 +217,7 @@ class RBuildPack(PythonBuildPack):
                     ),
                 },
             ).json()
-            # Construct a snapshot URL that will give us binary packages for Ubuntu Bionic (18.04)
+            # Construct a snapshot URL that will give us binary packages for appropriate ubuntu version
             if "upsi" in snapshots:
                 return (
                     # Env variables here are expanded by envsubst in the Dockerfile, after sourcing

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -105,7 +105,7 @@ def base_image():
     """
     Base ubuntu image to use when testing specific BuildPacks
     """
-    return "buildpack-deps:bionic"
+    return "buildpack-deps:jammy"
 
 
 def _add_content_to_git(repo_dir):


### PR DESCRIPTION
18.04 was EOL May 2023, with only paid support now available (https://ubuntu.com/blog/18-04-end-of-standard-support).

Let's bump the default base image to 22.04. This might break some repos that have apt.txt based packages, but I don't really think there's a way around that. If specific package pinning is needed, users unfortunately need to use a Dockerfile.

Closes #1258

<!--

Our guide to getting a PR merged https://repo2docker.readthedocs.io/en/latest/contributing/contributing.html#guidelines-to-getting-a-pull-request-merged.

About to propose a big change? Read https://repo2docker.readthedocs.io/en/latest/contributing/contributing.html#process-for-making-a-contribution to maximise the chances of it getting merged quickly.

-->
