### PR TITLE
Fix rstudio-build selection

### DIFF
--- a/repo2docker/buildpacks/_r_base.py
+++ b/repo2docker/buildpacks/_r_base.py
@@ -38,7 +38,7 @@ def rstudio_base_scripts(r_version):
             # which will upgrade the installed version of R, undoing our pinned version
             rf"""
             apt-get update > /dev/null && \
-            if apt-cache search libssl3 > /dev/null; then \
+            if apt-cache search libssl3 | grep -q libssl3; then \
               RSTUDIO_URL="{rstudio_openssl3_url}" ;\
               RSTUDIO_HASH="{rstudio_openssl3_sha256sum}" ;\
             else \


### PR DESCRIPTION
Fix https://github.com/jupyterhub/repo2docker/issues/1290. 

Note that `apt-cache search libssl3` returns the exit code 0 even if there is no match.

<!--

Our guide to getting a PR merged https://repo2docker.readthedocs.io/en/latest/contributing/contributing.html#guidelines-to-getting-a-pull-request-merged.

About to propose a big change? Read https://repo2docker.readthedocs.io/en/latest/contributing/contributing.html#process-for-making-a-contribution to maximise the chances of it getting merged quickly.

-->
