### PR TITLE
Point to official documentation for handling JupyterLab workspace

### DIFF
--- a/docs/source/howto/lab_workspaces.rst
+++ b/docs/source/howto/lab_workspaces.rst
@@ -14,6 +14,6 @@ another JupyterLab installation in order to share a workspace with
 someone else.
 
 In order to package your workspace with a repository, we recommend
-following the steps in this example repository:
+following the steps in the documentation:
 
-https://github.com/ian-r-rose/binder-workspace-demo/
+https://jupyterlab.readthedocs.io/en/stable/user/binder.html#customize-the-layout


### PR DESCRIPTION
<!--

Our guide to getting a PR merged https://repo2docker.readthedocs.io/en/latest/contributing/contributing.html#guidelines-to-getting-a-pull-request-merged.

About to propose a big change? Read https://repo2docker.readthedocs.io/en/latest/contributing/contributing.html#process-for-making-a-contribution to maximise the chances of it getting merged quickly.

-->

This changes a link from an unmaintained repository to the official JupyterLab documentation.