### PR TITLE
rstudio: log-level info to stderr

### DIFF
--- a/repo2docker/buildpacks/r.py
+++ b/repo2docker/buildpacks/r.py
@@ -340,6 +340,15 @@ class RBuildPack(PythonBuildPack):
                 """,
             ),
             (
+                "root",
+                # Configure log-level and send to stderr
+                # Set log-level=debug to investigate problems
+                # https://docs.posit.co/ide/server-pro/server_management/logging.html
+                rf"""
+                printf '[*]\nlog-level=info\nlogger-type=stderr\n' > /etc/rstudio/logging.conf
+                """,
+            ),
+            (
                 "${NB_USER}",
                 # Install a pinned version of devtools, IRKernel and shiny
                 rf"""


### PR DESCRIPTION
This is useful for investigating RStudio problems, such as https://github.com/jupyterhub/repo2docker/issues/1316.

In future it'd be nice if we had an easy way to set the log level to `debug` for investigating problems, but for now you'll need to modify the R2D source code.