### PR TITLE
New domain for Edmond MPG repository

### DIFF
--- a/repo2docker/contentproviders/dataverse.json
+++ b/repo2docker/contentproviders/dataverse.json
@@ -639,16 +639,29 @@
         },
         {
             "description": "The Research Data Repository for the Max Planck Society.",
-            "full_name": "Edmond - Research Data Repository for the Max Planck Society",
+            "full_name": "Edmond - Research Data Repository for the Max Planck Society (old domain)",
             "id": 1795,
             "is_active": true,
             "lat": 48.1366,
             "lng": 11.5771,
             "logo": "https://edmond.mpdl.mpg.de/logos/navbar/logo_for_bright.png",
-            "name": "Edmond",
-            "slug": "",
+            "name": "Edmond (old domain)",
+            "slug": "edmond_mpdl_mpg_de",
             "url": "https://edmond.mpdl.mpg.de",
-            "version": "5.10"
+            "version": "5.14"
+        },
+        {
+            "description": "The Research Data Repository for the Max Planck Society.",
+            "full_name": "Edmond - Research Data Repository for the Max Planck Society",
+            "id": 1796,
+            "is_active": true,
+            "lat": 48.1366,
+            "lng": 11.5771,
+            "logo": "https://edmond.mpdl.mpg.de/logos/navbar/logo_for_bright.png",
+            "name": "Edmond",
+            "slug": "edmond_mpg_de",
+            "url": "https://edmond.mpg.de",
+            "version": "5.14"
         }        
     ]
 }

--- a/repo2docker/contentproviders/dataverse.json
+++ b/repo2docker/contentproviders/dataverse.json
@@ -657,7 +657,7 @@
             "is_active": true,
             "lat": 48.1366,
             "lng": 11.5771,
-            "logo": "https://edmond.mpdl.mpg.de/logos/navbar/logo_for_bright.png",
+            "logo": "https://edmond.mpg.de/logos/navbar/logo_for_bright.png",
             "name": "Edmond",
             "slug": "edmond_mpg_de",
             "url": "https://edmond.mpg.de",


### PR DESCRIPTION
We recently moved our Dataverse repository "Edmond" from https://edmond.mpdl.mpg.de to https://edmond.mpg.de.

Currently, we still have old DOIs registered with the old URL, new DOIs are registered with the new URL. There are of course redirects, but as the dataverse.py script directly compares the URL from the DOI with the list of dataverse installations, DOIs with the new URL do not work with MyBinder anymore.

This pull requests adds a second entry for "Edmond" with the new domain, so both types of URLs should work. This is just a temporary solution. We are planning  to migrate the old DOIs to the new domain. As soon as this process is finished, the entry for the old domain could be deleted (we will provide another pull request then).
In the meantime, we'd appreciate if you allow us two entries. Thank you.
