### PR TITLE
Support pytest=8

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,6 +2,6 @@ build
 conda-lock
 pre-commit
 pytest-cov
-pytest>=7,<9
+pytest>=7
 pyyaml
 requests_mock

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,6 +2,6 @@ build
 conda-lock
 pre-commit
 pytest-cov
-pytest>=4.6,<8
+pytest>=7,<9
 pyyaml
 requests_mock

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,6 +2,6 @@ build
 conda-lock
 pre-commit
 pytest-cov
-pytest>=4.6
+pytest>=4.6,<8
 pyyaml
 requests_mock


### PR DESCRIPTION
pytest 8 breaks our tests:
```
ERROR tests/base/node - pytest.PytestRemovedIn8Warning: The (fspath: py.path.local) argument to LocalRepo is deprecated. Please use the (path: pathlib.Path) argument instead.
See https://docs.pytest.org/en/latest/deprecations.html#fspath-argument-for-node-constructors-replaced-with-pathlib-path
```

Reported in https://github.com/jupyterhub/repo2docker/pull/1329#issuecomment-1913608729