### PR TITLE
Dockerfile: update alpine from 3.17 to 3.18, and Python 3.10 to 3.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax = docker/dockerfile:1.3
-ARG ALPINE_VERSION=3.17
+ARG ALPINE_VERSION=3.18
 FROM alpine:${ALPINE_VERSION}
 
 RUN apk add --no-cache git python3 python3-dev py3-pip py3-setuptools build-base


### PR DESCRIPTION
This seems to resolve https://github.com/jupyterhub/repo2docker-action/issues/113 which seem to stem from an issue in alpine:3.17 that has arisen - maybe it will get fixed over time - but I think this could also do the trick.