### PR TITLE
Docker engine: replace ContainerConfig with Config

### DIFF
--- a/repo2docker/docker.py
+++ b/repo2docker/docker.py
@@ -117,7 +117,7 @@ class DockerEngine(ContainerEngine):
 
     def inspect_image(self, image):
         image = self._apiclient.inspect_image(image)
-        return Image(tags=image["RepoTags"], config=image["ContainerConfig"])
+        return Image(tags=image["RepoTags"], config=image["Config"])
 
     def push(self, image_spec):
         if self.registry_credentials:


### PR DESCRIPTION
`ContainerConfig` has been removed, https://docs.docker.com/engine/deprecated/#container-and-containerconfig-fields-in-image-inspect says to use `Config`.

AFAIK the presence or absence of this field depends on the Docker host daemon, not docker-py.

Closes https://github.com/jupyterhub/repo2docker/issues/1354