### PR TITLE
BUG: buildpacks/base.py: COPY --chmod to allow non-root users to run python3-login and repo2docker-entrypoint

### DIFF
--- a/repo2docker/buildpacks/base.py
+++ b/repo2docker/buildpacks/base.py
@@ -186,8 +186,8 @@ ENV R2D_ENTRYPOINT="{{ start_script }}"
 
 # Add entrypoint
 ENV PYTHONUNBUFFERED=1
-COPY /python3-login /usr/local/bin/python3-login
-COPY /repo2docker-entrypoint /usr/local/bin/repo2docker-entrypoint
+COPY --chmod=0755 /python3-login /usr/local/bin/python3-login
+COPY --chmod=0755 /repo2docker-entrypoint /usr/local/bin/repo2docker-entrypoint
 ENTRYPOINT ["/usr/local/bin/repo2docker-entrypoint"]
 
 # Specify the default command to run


### PR DESCRIPTION

- Fixes #921 and the `/bin/bash: /usr/local/bin/python3-login: Permission denied` error
  that's blocking use with repo2podman and rootless containers

<!--

Our guide to getting a PR merged https://repo2docker.readthedocs.io/en/latest/contributing/contributing.html#guidelines-to-getting-a-pull-request-merged.

About to propose a big change? Read https://repo2docker.readthedocs.io/en/latest/contributing/contributing.html#process-for-making-a-contribution to maximise the chances of it getting merged quickly.

-->
