### PR TITLE
exclude defaults channel by default

### DIFF
--- a/repo2docker/buildpacks/conda/install-base-env.bash
+++ b/repo2docker/buildpacks/conda/install-base-env.bash
@@ -30,7 +30,6 @@ export PATH="${PWD}/bin:$PATH"
 cat <<EOT >> ${CONDA_DIR}/.condarc
 channels:
   - conda-forge
-  - defaults
 auto_update_conda: false
 show_channel_urls: true
 update_dependencies: false

--- a/tests/conda/downgrade/verify
+++ b/tests/conda/downgrade/verify
@@ -27,4 +27,4 @@ assert pkgs["xeus-cling"]["version"] == "0.6.0"
 # which in turn downgrades Python from >=3.9.16 to 3.9.6
 
 assert pkgs["openssl"]["version"].startswith("1.1.1"), pkgs["openssl"]["version"]
-assert pkgs["python"]["version"] == "3.9.6", pkgs["python"]["version"]
+assert pkgs["python"]["version"] == "3.9.0", pkgs["python"]["version"]


### PR DESCRIPTION
make sure we're always using conda-forge by default

it's unlikely any packages came from defaults for users in some years (due to channel priority, this would only happen for packages not on conda-forge, and would often result in a broken env anyway), but this ensures defaults channel is opt-in, as it should be for the Anaconda ToS.