### PR TITLE
TarFile.add: don't add recursively

### DIFF
--- a/repo2docker/buildpacks/base.py
+++ b/repo2docker/buildpacks/base.py
@@ -630,7 +630,7 @@ class BuildPack:
 
         if files_to_add:
             for item in files_to_add:
-                tar.add(item, f"src/{item}", filter=_filter_tar)
+                tar.add(item, f"src/{item}", recursive=False, filter=_filter_tar)
         else:
             # Either the source was empty or everything was filtered out.
             # In any case, create an src dir so the build can proceed.


### PR DESCRIPTION
`exclude_paths` lists files and directories individually:
https://github.com/docker/docker-py/blob/7.1.0/docker/utils/build.py#L41-L48

[`TarFile.add`](https://docs.python.org/3/library/tarfile.html#tarfile.TarFile.add) defaults to `recursive=True`, leading to duplicate files being added. This may cause
https://github.com/manics/repo2podman/blob/141bf4f5902f58ac25ad9302eae23437e1d41e54/repo2podman/podman.py#L459-L460
to fail with `PermissionError: [Errno 13] Permission denied: ` when it tries to overwrite the file that was just extracted with a duplicate copy (possible race condition?)