### PR TITLE
julia_project.py: fix Pkg REPL api warning

### DIFF
--- a/repo2docker/buildpacks/julia/julia_project.py
+++ b/repo2docker/buildpacks/julia/julia_project.py
@@ -177,7 +177,7 @@ class JuliaProjectTomlBuildPack(PythonBuildPack):
                 "${NB_USER}",
                 r"""
             JULIA_PROJECT="" julia -e "using Pkg; Pkg.add(\"IJulia\"); using IJulia; installkernel(\"Julia\", \"--project={project}\");" && \
-            julia --project={project} -e 'using Pkg; Pkg.instantiate(); Pkg.resolve(); pkg"precompile"'
+            julia --project={project} -e 'using Pkg; Pkg.instantiate(); Pkg.resolve(); Pkg.instantiate()'
             """.format(
                     project=self.project_dir
                 ),


### PR DESCRIPTION
Repo2docker currently prints this warning when using a Julia project:

```
Warning: The Pkg REPL mode is intended for interactive use only, and should not be used from scripts. It is recommended to use the functional API instead.
└ @ Pkg.REPLMode /srv/julia/share/julia/stdlib/v1.10/Pkg/src/REPLMode/REPLMode.jl:382
[0m  at 12:24:22
```

This PR fixes that. I also used `Pkg.instantiate()` instead of `Pkg.precompile()` because it makes a bit more sense in this context: we want to guarantee that packages are instantiated (which precompiles at the end), not just that they are precompiled: https://pkgdocs.julialang.org/v1/api/#Pkg.instantiate

I believe that `resolve` already instantiates (and precompiles), but this is not defined in spec so it is good to add the `instantiate` call.