### PR TITLE
Use self.log.warning instead of warnings.warn

### DIFF
--- a/repo2docker/app.py
+++ b/repo2docker/app.py
@@ -16,7 +16,6 @@ import shutil
 import sys
 import tempfile
 import time
-import warnings
 from urllib.parse import urlparse
 
 import entrypoints

--- a/repo2docker/app.py
+++ b/repo2docker/app.py
@@ -267,7 +267,7 @@ class Repo2Docker(Application):
         """
         p = get_platform()
         if p == "linux/arm64":
-            warnings.warn(
+            self.log.warning(
                 "Building for linux/arm64 is experimental. "
                 "To use the recommended platform set --Repo2Docker.platform=linux/amd64. "
                 "To silence this warning set --Repo2Docker.platform=linux/arm64."

--- a/repo2docker/buildpacks/conda/__init__.py
+++ b/repo2docker/buildpacks/conda/__init__.py
@@ -355,7 +355,7 @@ class CondaBuildPack(BaseImage):
     @property
     def py2(self):
         """Am I building a Python 2 kernel environment?"""
-        warnings.warn(
+        self.log.warning(
             "CondaBuildPack.py2 is deprecated in 2023.2. Use CondaBuildPack.separate_kernel_env.",
             DeprecationWarning,
             stacklevel=2,

--- a/repo2docker/buildpacks/conda/__init__.py
+++ b/repo2docker/buildpacks/conda/__init__.py
@@ -2,7 +2,6 @@
 
 import os
 import re
-import warnings
 from collections.abc import Mapping
 from functools import lru_cache
 

--- a/repo2docker/utils.py
+++ b/repo2docker/utils.py
@@ -543,5 +543,4 @@ def get_platform():
         # OSX reports arm64
         return "linux/arm64"
     else:
-        warnings.warn(f"Unexpected platform '{m}', defaulting to linux/amd64")
-        return "linux/amd64"
+        raise ValueError("Unsupported platform {m}")

--- a/repo2docker/utils.py
+++ b/repo2docker/utils.py
@@ -543,4 +543,5 @@ def get_platform():
         # OSX reports arm64
         return "linux/arm64"
     else:
-        raise ValueError("Unsupported platform {m}")
+        warnings.warn(f"Unexpected platform '{m}', defaulting to linux/amd64")
+        return "linux/amd64"


### PR DESCRIPTION
warnings.warn sidesteps all the json logging bits we do, and repo2docker will produce non-json output that binderhub then struggles to consume.

