### PR TITLE
Resolve DOI more cleanly

### DIFF
--- a/repo2docker/contentproviders/doi.py
+++ b/repo2docker/contentproviders/doi.py
@@ -62,7 +62,7 @@ class DoiProvider(ContentProvider):
                 # default Git provider as this leads to a misleading error.
                 self.log.error(f"DOI {doi} does not resolve: {e}")
                 raise
-            return resp.headers['Location']
+            return resp.headers["Location"]
         else:
             # Just return what is actulally just a URL
             return doi

--- a/repo2docker/contentproviders/doi.py
+++ b/repo2docker/contentproviders/doi.py
@@ -49,7 +49,9 @@ class DoiProvider(ContentProvider):
             doi = normalize_doi(doi)
 
             try:
-                resp = self._request(f"https://doi.org/{doi}")
+                # We don't need to fetch the *contents* of the page the doi resolves to -
+                # only need to know what it redirects to.
+                resp = self._request(f"https://doi.org/{doi}", allow_redirects=False)
                 resp.raise_for_status()
             except HTTPError as e:
                 # If the DOI doesn't exist, just return URL
@@ -60,7 +62,7 @@ class DoiProvider(ContentProvider):
                 # default Git provider as this leads to a misleading error.
                 self.log.error(f"DOI {doi} does not resolve: {e}")
                 raise
-            return resp.url
+            return resp.headers['Location']
         else:
             # Just return what is actulally just a URL
             return doi

--- a/tests/unit/contentproviders/test_dataverse.py
+++ b/tests/unit/contentproviders/test_dataverse.py
@@ -70,8 +70,8 @@ def test_detect_dataverse(test_input, expected, requests_mock):
     assert requests_mock.call_count == 0
     # valid Dataverse DOIs trigger this content provider
     assert Dataverse().detect(test_input[0]) == expected[0]
-    # 4: doi resolution (302), File, doi resolution (302), then dataset
-    assert requests_mock.call_count == 4
+    # 4: doi resolution (302), doi resolution (302)
+    assert requests_mock.call_count == 2
     requests_mock.reset_mock()
 
     assert Dataverse().detect(test_input[1]) == expected[0]

--- a/tests/unit/contentproviders/test_doi.py
+++ b/tests/unit/contentproviders/test_doi.py
@@ -33,7 +33,7 @@ def test_url_headers(requests_mock):
 @pytest.mark.parametrize(
     "requested_doi, expected",
     [
-        ("10.5281/zenodo.3242074", "https://zenodo.org/records/3242074"),
+        ("10.5281/zenodo.3242074", "https://zenodo.org/record/3242074"),
         # Unresolving DOI:
         ("10.1/1234", "10.1/1234"),
     ],

--- a/tests/unit/contentproviders/test_hydroshare.py
+++ b/tests/unit/contentproviders/test_hydroshare.py
@@ -75,8 +75,8 @@ def test_detect_hydroshare(requests_mock):
     assert (
         Hydroshare().detect("10.4211/hs.b8f6eae9d89241cf8b5904033460af61") == expected
     )
-    # assert 3 calls were made, 2 to resolve the DOI (302 + 200) and another to fetch the version
-    assert requests_mock.call_count == 3
+    # assert 2 calls were made, 1 to resolve the DOI (302) and another to fetch the version
+    assert requests_mock.call_count == 2
     requests_mock.reset_mock()
 
     assert (

--- a/tests/unit/contentproviders/test_zenodo.py
+++ b/tests/unit/contentproviders/test_zenodo.py
@@ -66,8 +66,8 @@ def test_detect_zenodo(test_input, expected, requests_mock):
     assert Zenodo().detect(test_input[0]) == expected
     assert Zenodo().detect(test_input[1]) == expected
     assert Zenodo().detect(test_input[2]) == expected
-    # only two of the three calls above have to resolve a DOI (2 req per doi resolution)
-    assert requests_mock.call_count == 4
+    # only two of the three calls above have to resolve a DOI (1 req per doi resolution)
+    assert requests_mock.call_count == 2
     requests_mock.reset_mock()
 
     # Don't trigger the Zenodo content provider


### PR DESCRIPTION
Using doi.org, we only care to find out *where* the doi is pointing to. We don't need to go fetch the contents of that page fully.

By doing this, we:

1. Make doi resolution much faster, as we now make only 1 request per doi resolution than two!
2. Handle circumstances where dataverse (or other providers) restrict requests from datacenter IPs for subsets of URLs that serve HTML, rather than API requests (https://jupyter.zulipchat.com/#narrow/channel/103349-ask-anything/topic/Binder.20Dataverse.20error) 