### PR TITLE
Remove unused _urlopen method

### DIFF
--- a/repo2docker/contentproviders/doi.py
+++ b/repo2docker/contentproviders/doi.py
@@ -29,19 +29,6 @@ class DoiProvider(ContentProvider):
 
     urlopen = _request
 
-    def _urlopen(self, req, headers=None):
-        """A urlopen() helper"""
-        # someone passed a string, not a request
-        if not isinstance(req, request.Request):
-            req = request.Request(req)
-
-        req.add_header("User-Agent", f"repo2docker {__version__}")
-        if headers is not None:
-            for key, value in headers.items():
-                req.add_header(key, value)
-
-        return request.urlopen(req)
-
     def doi2url(self, doi):
         # Transform a DOI to a URL
         # If not a doi, assume we have a URL and return

--- a/tests/unit/contentproviders/test_figshare.py
+++ b/tests/unit/contentproviders/test_figshare.py
@@ -129,7 +129,6 @@ def test_fetch_zip(requests_mock):
         )
         requests_mock.get(f"file://{fig_path}", content=open(fig_path, "rb").read())
 
-        # with patch.object(Figshare, "urlopen", new=mock_urlopen):
         with TemporaryDirectory() as d:
             output = []
             for l in test_fig.fetch(test_spec, d):

--- a/tests/unit/contentproviders/test_swhid.py
+++ b/tests/unit/contentproviders/test_swhid.py
@@ -56,7 +56,6 @@ def test_detect(swhid, expected):
     assert provider.detect(swhid) == expected
 
 
-
 def test_unresolving_swhid():
     provider = Swhid()
 

--- a/tests/unit/contentproviders/test_swhid.py
+++ b/tests/unit/contentproviders/test_swhid.py
@@ -56,10 +56,6 @@ def test_detect(swhid, expected):
     assert provider.detect(swhid) == expected
 
 
-def fake_urlopen(req):
-    print(req)
-    return req.headers
-
 
 def test_unresolving_swhid():
     provider = Swhid()


### PR DESCRIPTION
This was never used anywhere, and actually didn't even import - 'request' is actually urllib.request, not requests. It was never imported but used here!

<!--

Our guide to getting a PR merged https://repo2docker.readthedocs.io/en/latest/contributing/contributing.html#guidelines-to-getting-a-pull-request-merged.

About to propose a big change? Read https://repo2docker.readthedocs.io/en/latest/contributing/contributing.html#process-for-making-a-contribution to maximise the chances of it getting merged quickly.

-->
