### PR TITLE
Shell out to `docker buildx build` to build images

### DIFF
--- a/repo2docker/__main__.py
+++ b/repo2docker/__main__.py
@@ -141,7 +141,7 @@ def get_argparser():
     argparser.add_argument(
         "--build-memory-limit",
         # Removed argument, but we still want to support printing an error message if this is passed
-        help=argparse.SUPPRESS
+        help=argparse.SUPPRESS,
     )
 
     argparser.add_argument(
@@ -437,7 +437,10 @@ def make_r2d(argv=None):
     if args.build_memory_limit:
         # We no longer support build_memory_limit, it must be set in the builder instance
         print("--build-memory-limit is no longer supported", file=sys.stderr)
-        print("Use `docker buildx create` to create a custom builder with appropriate memory limits instead", file=sys.stderr)
+        print(
+            "Use `docker buildx create` to create a custom builder with appropriate memory limits instead",
+            file=sys.stderr,
+        )
         sys.exit(-1)
 
     if args.environment and not r2d.run:

--- a/repo2docker/__main__.py
+++ b/repo2docker/__main__.py
@@ -438,7 +438,7 @@ def make_r2d(argv=None):
         # We no longer support build_memory_limit, it must be set in the builder instance
         print("--build-memory-limit is no longer supported", file=sys.stderr)
         print(
-            "Use `docker buildx create` to create a custom builder with appropriate memory limits instead",
+            "Check your build engine documentation to set memory limits. Use `docker buildx create` if using the default builder to create a custom builder with appropriate memory limits",
             file=sys.stderr,
         )
         sys.exit(-1)

--- a/repo2docker/__main__.py
+++ b/repo2docker/__main__.py
@@ -140,7 +140,8 @@ def get_argparser():
 
     argparser.add_argument(
         "--build-memory-limit",
-        help="Total Memory that can be used by the docker build process",
+        # Removed argument, but we still want to support printing an error message if this is passed
+        help=argparse.SUPPRESS
     )
 
     argparser.add_argument(
@@ -434,12 +435,10 @@ def make_r2d(argv=None):
         sys.exit(1)
 
     if args.build_memory_limit:
-        # if the string only contains numerals we assume it should be an int
-        # and specifies a size in bytes
-        if args.build_memory_limit.isnumeric():
-            r2d.build_memory_limit = int(args.build_memory_limit)
-        else:
-            r2d.build_memory_limit = args.build_memory_limit
+        # We no longer support build_memory_limit, it must be set in the builder instance
+        print("--build-memory-limit is no longer supported", file=sys.stderr)
+        print("Use `docker buildx create` to create a custom builder with appropriate memory limits instead", file=sys.stderr)
+        sys.exit(-1)
 
     if args.environment and not r2d.run:
         print("To specify environment variables, you also need to run " "the container")

--- a/repo2docker/app.py
+++ b/repo2docker/app.py
@@ -165,12 +165,19 @@ class Repo2Docker(Application):
     build_memory_limit = ByteSpecification(
         0,
         help="""
-        Total memory that can be used by the docker image building process.
+        Unsupported.
 
-        Set to 0 for no limits.
+        When using docker, please use `docker buildx create` to create a new buildkit
+        builder with appropriate limits instead.
         """,
         config=True,
     )
+
+    @observe("build_memory_limit")
+    def build_memory_limit_changed(self, change):
+        print("Setting build_memory_limit is not supported", file=sys.stderr)
+        print("Use `docker buildx create` to create a custom builder with appropriate memory limits instead", file=sys.stderr)
+        sys.exit(-1)
 
     volumes = Dict(
         {},
@@ -856,6 +863,7 @@ class Repo2Docker(Application):
                     for l in picked_buildpack.build(
                         docker_client,
                         self.output_image_spec,
+                        # This is deprecated, but passing it anyway to not break backwards compatibility
                         self.build_memory_limit,
                         build_args,
                         self.cache_from,

--- a/repo2docker/app.py
+++ b/repo2docker/app.py
@@ -177,7 +177,7 @@ class Repo2Docker(Application):
     def build_memory_limit_changed(self, change):
         print("Setting build_memory_limit is not supported", file=sys.stderr)
         print(
-            "Use `docker buildx create` to create a custom builder with appropriate memory limits instead",
+            "Check your build engine documentation to set memory limits. Use `docker buildx create` if using the default builder to create a custom builder with appropriate memory limits",
             file=sys.stderr,
         )
         sys.exit(-1)

--- a/repo2docker/app.py
+++ b/repo2docker/app.py
@@ -176,7 +176,10 @@ class Repo2Docker(Application):
     @observe("build_memory_limit")
     def build_memory_limit_changed(self, change):
         print("Setting build_memory_limit is not supported", file=sys.stderr)
-        print("Use `docker buildx create` to create a custom builder with appropriate memory limits instead", file=sys.stderr)
+        print(
+            "Use `docker buildx create` to create a custom builder with appropriate memory limits instead",
+            file=sys.stderr,
+        )
         sys.exit(-1)
 
     volumes = Dict(

--- a/repo2docker/docker.py
+++ b/repo2docker/docker.py
@@ -75,12 +75,12 @@ class DockerEngine(ContainerEngine):
     )
 
     extra_buildx_build_args = List(
-        Unicode,
+        [Unicode],
         [],
         help="""
         Extra commandline arguments to pass to `docker buildx build` when building the image.
         """,
-        help=True
+        config=True
     )
 
     def __init__(self, *, parent):

--- a/repo2docker/docker.py
+++ b/repo2docker/docker.py
@@ -117,7 +117,7 @@ class DockerEngine(ContainerEngine):
             args += ["--tag", tag]
 
         if labels:
-            for k, v in labels:
+            for k, v in labels.items():
                 args += ["--label", f"{k}={v}"]
 
         if platform:

--- a/repo2docker/docker.py
+++ b/repo2docker/docker.py
@@ -116,6 +116,13 @@ class DockerEngine(ContainerEngine):
         if tag:
             args += ["--tag", tag]
 
+        if labels:
+            for k, v in labels:
+                args += ["--label", f"{k}={v}"]
+
+        if platform:
+            args += ["--platform", platform]
+
         if fileobj:
             with tempfile.TemporaryDirectory() as d:
                 tarf = tarfile.open(fileobj=fileobj)

--- a/repo2docker/docker.py
+++ b/repo2docker/docker.py
@@ -75,7 +75,6 @@ class DockerEngine(ContainerEngine):
     )
 
     extra_buildx_build_args = List(
-        [Unicode],
         [],
         help="""
         Extra commandline arguments to pass to `docker buildx build` when building the image.

--- a/repo2docker/docker.py
+++ b/repo2docker/docker.py
@@ -89,8 +89,8 @@ class DockerEngine(ContainerEngine):
     def build(
         self,
         *,
-        buildargs: dict | None = None,
-        cache_from: list[str] | None = None,
+        buildargs=None,
+        cache_from=None,
         container_limits=None,
         tag="",
         custom_context=False,

--- a/repo2docker/docker.py
+++ b/repo2docker/docker.py
@@ -124,6 +124,11 @@ class DockerEngine(ContainerEngine):
                 args += [d]
 
                 yield from execute_cmd(args, True)
+        else:
+            # Assume 'path' is passed in
+            args += [path]
+
+            yield from execute_cmd(args, True)
 
     def images(self):
         images = self._apiclient.images()

--- a/repo2docker/docker.py
+++ b/repo2docker/docker.py
@@ -101,7 +101,7 @@ class DockerEngine(ContainerEngine):
         platform=None,
         **kwargs,
     ):
-        args = ["docker", "buildx", "build", "--progress", "plain"]
+        args = ["docker", "buildx", "build", "--progress", "plain", "--load"]
         if buildargs:
             for k, v in buildargs.items():
                 args += ["--build-arg", f"{k}={v}"]

--- a/repo2docker/docker.py
+++ b/repo2docker/docker.py
@@ -7,7 +7,7 @@ import tarfile
 import tempfile
 
 from iso8601 import parse_date
-from traitlets import Dict
+from traitlets import Dict, List, Unicode
 
 import docker
 
@@ -74,6 +74,15 @@ class DockerEngine(ContainerEngine):
         config=True,
     )
 
+    extra_buildx_build_args = List(
+        Unicode,
+        [],
+        help="""
+        Extra commandline arguments to pass to `docker buildx build` when building the image.
+        """,
+        help=True
+    )
+
     def __init__(self, *, parent):
         super().__init__(parent=parent)
         try:
@@ -122,6 +131,9 @@ class DockerEngine(ContainerEngine):
 
         if platform:
             args += ["--platform", platform]
+
+        # place extra args right *before* the path
+        args += self.extra_buildx_build_args
 
         if fileobj:
             with tempfile.TemporaryDirectory() as d:

--- a/repo2docker/docker.py
+++ b/repo2docker/docker.py
@@ -80,7 +80,7 @@ class DockerEngine(ContainerEngine):
         help="""
         Extra commandline arguments to pass to `docker buildx build` when building the image.
         """,
-        config=True
+        config=True,
     )
 
     def __init__(self, *, parent):

--- a/repo2docker/docker.py
+++ b/repo2docker/docker.py
@@ -2,11 +2,9 @@
 Docker container engine for repo2docker
 """
 
-import subprocess
+import shutil
 import tarfile
 import tempfile
-from queue import Empty, Queue
-from threading import Thread
 
 from iso8601 import parse_date
 from traitlets import Dict
@@ -101,6 +99,8 @@ class DockerEngine(ContainerEngine):
         platform=None,
         **kwargs,
     ):
+        if not shutil.which("docker"):
+            raise RuntimeError("The docker commandline client must be installed")
         args = ["docker", "buildx", "build", "--progress", "plain", "--load"]
         if buildargs:
             for k, v in buildargs.items():

--- a/repo2docker/docker.py
+++ b/repo2docker/docker.py
@@ -75,7 +75,7 @@ class DockerEngine(ContainerEngine):
     )
 
     extra_buildx_build_args = List(
-        [],
+        Unicode(),
         help="""
         Extra commandline arguments to pass to `docker buildx build` when building the image.
         """,

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -92,7 +92,6 @@ def test_run_kwargs(repo_with_content):
     assert kwargs["somekey"] == "somevalue"
 
 
-
 def test_dryrun_works_without_docker(tmpdir, capsys):
     with chdir(tmpdir):
         with patch.object(docker, "APIClient") as client:

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -80,11 +80,11 @@ def test_local_dir_image_name(repo_with_content):
 
 def test_extra_buildx_build_args(repo_with_content):
     upstream, sha1 = repo_with_content
-    argv = ['--DockerEngine.extra_buildx_build_args=--check', upstream]
+    argv = ["--DockerEngine.extra_buildx_build_args=--check", upstream]
     app = make_r2d(argv)
     with patch("repo2docker.docker.execute_cmd") as execute_cmd:
         app.build()
-        
+
     args, kwargs = execute_cmd.call_args
     cmd = args[0]
     assert cmd[:3] == ["docker", "buildx", "build"]

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -78,6 +78,20 @@ def test_local_dir_image_name(repo_with_content):
     )
 
 
+def test_extra_buildx_build_args(repo_with_content):
+    upstream, sha1 = repo_with_content
+    argv = ['--DockerEngine.extra_buildx_build_args=--check', upstream]
+    app = make_r2d(argv)
+    with patch("repo2docker.docker.execute_cmd") as execute_cmd:
+        app.build()
+        
+    args, kwargs = execute_cmd.call_args
+    cmd = args[0]
+    assert cmd[:3] == ["docker", "buildx", "build"]
+    # make sure it's inserted before the end
+    assert "--check" in cmd[:-1]
+
+
 def test_run_kwargs(repo_with_content):
     upstream, sha1 = repo_with_content
     argv = [upstream]

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -78,21 +78,6 @@ def test_local_dir_image_name(repo_with_content):
     )
 
 
-def test_build_kwargs(repo_with_content):
-    upstream, sha1 = repo_with_content
-    argv = [upstream]
-    app = make_r2d(argv)
-    app.extra_build_kwargs = {"somekey": "somevalue"}
-
-    with patch.object(docker.APIClient, "build") as builds:
-        builds.return_value = []
-        app.build()
-    builds.assert_called_once()
-    args, kwargs = builds.call_args
-    assert "somekey" in kwargs
-    assert kwargs["somekey"] == "somevalue"
-
-
 def test_run_kwargs(repo_with_content):
     upstream, sha1 = repo_with_content
     argv = [upstream]
@@ -106,25 +91,6 @@ def test_run_kwargs(repo_with_content):
     assert "somekey" in kwargs
     assert kwargs["somekey"] == "somevalue"
 
-
-def test_root_not_allowed():
-    with TemporaryDirectory() as src, patch("os.geteuid") as geteuid:
-        geteuid.return_value = 0
-        argv = [src]
-        with pytest.raises(SystemExit) as exc:
-            app = make_r2d(argv)
-            assert exc.code == 1
-
-        with pytest.raises(ValueError):
-            app = Repo2Docker(repo=src, run=False)
-            app.build()
-
-        app = Repo2Docker(repo=src, user_id=1000, user_name="jovyan", run=False)
-        app.initialize()
-        with patch.object(docker.APIClient, "build") as builds:
-            builds.return_value = []
-            app.build()
-        builds.assert_called_once()
 
 
 def test_dryrun_works_without_docker(tmpdir, capsys):

--- a/tests/unit/test_args.py
+++ b/tests/unit/test_args.py
@@ -56,6 +56,7 @@ def test_mem_limit():
     with pytest.raises(SystemExit):
         r2d = make_r2d(["--Repo2Docker.build_memory_limit", "1024", "."])
 
+
 def test_run_required():
     """
     Test all the things that should fail if we pass in --no-run

--- a/tests/unit/test_args.py
+++ b/tests/unit/test_args.py
@@ -50,11 +50,8 @@ def test_mem_limit():
     """
     Test various ways of passing --build-memory-limit
     """
-    r2d = make_r2d(["--build-memory-limit", "1024", "."])
-    assert int(r2d.build_memory_limit) == 1024
-
-    r2d = make_r2d(["--build-memory-limit", "3K", "."])
-    assert int(r2d.build_memory_limit) == 1024 * 3
+    with pytest.raises(SystemExit):
+        r2d = make_r2d(["--build-memory-limit", "1024", "."])
 
 
 def test_run_required():

--- a/tests/unit/test_args.py
+++ b/tests/unit/test_args.py
@@ -53,6 +53,8 @@ def test_mem_limit():
     with pytest.raises(SystemExit):
         r2d = make_r2d(["--build-memory-limit", "1024", "."])
 
+    with pytest.raises(SystemExit):
+        r2d = make_r2d(["--Repo2Docker.build_memory_limit", "1024", "."])
 
 def test_run_required():
     """


### PR DESCRIPTION
pydocker uses the HTTP API (equivalent to `docker build`) which has been dead for ages. `docker buildx` (the interface to BuildKit) is what we *should* be using, but alas pydocker does not currently support it and I suspect it never will (https://github.com/docker/docker-py/issues/2230).

This PR simply shells out, as I think that's the way.

I'm going to list some intentional choices I've made here.

1. Intentionally replace the build functionality of the existing `DockerEngine` than make a new one. The old way is [deprecated](https://github.com/docker/buildx/issues/2297) and we should not support it.
2. Continue using `dockerpy` for all other non-build operations. It works fine and I don't see a need to change it right now.
3. Simply extract the tarball we construct elsewhere. This is kinda double work, but we can treat this as a possible optimization pathway in the future.
4. Currently ignore `container_limits` (because buildx doesn't support it, it should be set at the level of the builder instead)

## Questions to answer

- What do we do about container_limits here?
- We probably need to deprecate / throw errors on some existing traitlets as they won't really have any effect here. What traitlets are those?
- We should treat this as a breaking change and make a release after, right?

## Traitlets to deprecate

- `Repo2Docker.build_memory_limit` - this must be instead set up by the builder

Fixes https://github.com/jupyterhub/repo2docker/issues/875
