### PR TITLE
Don't run scheduled workflows on forks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,6 +42,9 @@ env:
 
 jobs:
   test:
+    # Don't run scheduled tests on forks
+    if: ${{ github.repository_owner == 'jupyterhub' || github.event_name != 'schedule' }}
+
     runs-on: ubuntu-${{ matrix.ubuntu_version }}
 
     strategy:


### PR DESCRIPTION
They idea behind the running tests on a weekly schedule is to have a rough timeframe for when external changes break our tests. We don't need to run them on forks.