### PR TITLE
`set -e` should not be set after conda environment is sourced

### DIFF
--- a/repo2docker/buildpacks/conda/activate-conda.sh
+++ b/repo2docker/buildpacks/conda/activate-conda.sh
@@ -1,5 +1,5 @@
 # enable conda and activate the notebook environment
-set -ex
+set -e
 eval $(micromamba shell hook -s posix -r ${CONDA_DIR})
 for name in conda mamba; do
     CONDA_PROFILE="${CONDA_DIR}/etc/profile.d/${name}.sh"
@@ -21,3 +21,5 @@ if [[ "${KERNEL_PYTHON_PREFIX}" != "${NB_PYTHON_PREFIX}" ]]; then
 else
     mamba activate ${NB_PYTHON_PREFIX}
 fi
+
+set +e

--- a/tests/venv/start/postBuild/README.rst
+++ b/tests/venv/start/postBuild/README.rst
@@ -3,3 +3,5 @@ postBuild and start
 
 This test checks that we can use a postBuild and start script
 at the same time.
+
+It also checks that exit on error (set -e) has not leaked into the main shell.

--- a/tests/venv/start/postBuild/verify
+++ b/tests/venv/start/postBuild/verify
@@ -1,4 +1,9 @@
-#!/bin/bash
+#!/bin/bash -il
+# Run this as an interactive login shell so that the conda profile is sourced
+
+# Test that `set -e` isn't incorrectly set in a profile
+false
+
 set -euo pipefail
 grep 'Done!' $HOME/postbuild.txt
 # set value of TEST_START_VAR to empty string when it is not defined


### PR DESCRIPTION
Closes https://github.com/jupyterhub/repo2docker/issues/1405