### PR TITLE
Require Python 3.9 to run repo2docker

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -29,7 +29,7 @@ on:
 
 jobs:
   docker:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: "3.13"
 
       - name: install build requirements
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ on:
 
 jobs:
   build-n-publish:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -62,7 +62,7 @@ jobs:
           password: ${{ secrets.PYPI_PASSWORD }}
 
   publish-docker:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     env:
       DEFAULT_REGISTRY: quay.io
       IMAGE_NAME: jupyterhub/repo2docker

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,7 +50,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ubuntu_version: ["22.04"]
+        ubuntu_version: ["24.04"]
         python_version: ["3.9"]
         repo_type:
           - base

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,7 +51,7 @@ jobs:
       fail-fast: false
       matrix:
         ubuntu_version: ["24.04"]
-        python_version: ["3.9"]
+        python_version: ["3.13"]
         repo_type:
           - base
           - conda
@@ -64,17 +64,13 @@ jobs:
           - unit
           - venv
           - contentproviders
-        include:
-          # The actions/setup-python action with Python version 3.6 isn't
-          # possible to use with the ubuntu-22.04 runner, so we use ubuntu-20.04
-          # for this test where Python 3.6 remain available.
-          - ubuntu_version: "20.04"
-            python_version: "3.6"
-            repo_type: venv
           # Playwright test
-          - ubuntu_version: "24.04"
-            python_version: "3.13"
-            repo_type: ui
+          - ui
+        include:
+          # The earliest actions/setup-python versions depend on the runner.
+          - ubuntu_version: "22.04"
+            python_version: "3.8"
+            repo_type: venv
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,7 +69,7 @@ jobs:
         include:
           # The earliest actions/setup-python versions depend on the runner.
           - ubuntu_version: "22.04"
-            python_version: "3.8"
+            python_version: "3.9"
             repo_type: venv
 
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,10 +15,10 @@ repos:
     hooks:
       - id: pyupgrade
         args:
-          - --py36-plus
+          - --py38-plus
         # check-tmp is a Python based test script run in created environments
-        # that can be at least Python 3.5 even though we require Python 3.6 for
-        # repo2docker itself.
+        # that can be Python 3.5, older than the Python version required to run
+        # repo2docker.
         exclude: check-tmp
 
   # Autoformat: Python code
@@ -27,12 +27,12 @@ repos:
     hooks:
       - id: black
         args:
-          - --target-version=py36
-          - --target-version=py37
           - --target-version=py38
           - --target-version=py39
           - --target-version=py310
           - --target-version=py311
+          - --target-version=py312
+          - --target-version=py313
 
   # Autoformat: Python code
   - repo: https://github.com/pycqa/isort

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,6 @@ repos:
     hooks:
       - id: black
         args:
-          - --target-version=py38
           - --target-version=py39
           - --target-version=py310
           - --target-version=py311

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ For more information, please visit
 
 1. Docker to build & run the repositories. The [community edition](https://store.docker.com/search?type=edition&offering=community)
    is recommended.
-2. Python 3.8+.
+2. Python 3.9+.
 
 Supported on Linux and macOS. [See documentation note about Windows support.](http://repo2docker.readthedocs.io/en/latest/install.html#note-about-windows-support)
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ For more information, please visit
 
 1. Docker to build & run the repositories. The [community edition](https://store.docker.com/search?type=edition&offering=community)
    is recommended.
-2. Python 3.6+.
+2. Python 3.8+.
 
 Supported on Linux and macOS. [See documentation note about Windows support.](http://repo2docker.readthedocs.io/en/latest/install.html#note-about-windows-support)
 

--- a/repo2docker/buildpacks/base.py
+++ b/repo2docker/buildpacks/base.py
@@ -236,7 +236,7 @@ class BuildPack:
             )
         self.platform = ""
 
-    @lru_cache()
+    @lru_cache
     def get_packages(self):
         """
         List of packages that are installed in this BuildPack.
@@ -246,7 +246,7 @@ class BuildPack:
         """
         return set()
 
-    @lru_cache()
+    @lru_cache
     def get_base_packages(self):
         """
         Base set of apt packages that are installed for all images.
@@ -265,7 +265,7 @@ class BuildPack:
             "gettext-base",
         }
 
-    @lru_cache()
+    @lru_cache
     def get_build_env(self):
         """
         Ordered list of environment variables to be set for this image.
@@ -281,7 +281,7 @@ class BuildPack:
         """
         return []
 
-    @lru_cache()
+    @lru_cache
     def get_env(self):
         """
         Ordered list of environment variables to be set for this image.
@@ -296,7 +296,7 @@ class BuildPack:
         """
         return []
 
-    @lru_cache()
+    @lru_cache
     def get_path(self):
         """
         Ordered list of file system paths to look for executables in.
@@ -306,14 +306,14 @@ class BuildPack:
         """
         return []
 
-    @lru_cache()
+    @lru_cache
     def get_labels(self):
         """
         Docker labels to set on the built image.
         """
         return self.labels
 
-    @lru_cache()
+    @lru_cache
     def get_build_script_files(self):
         """
         Dict of files to be copied to the container image for use in building.
@@ -338,7 +338,7 @@ class BuildPack:
                     f"Found a stencila manifest.xml at {root}. Stencila is no longer supported."
                 )
 
-    @lru_cache()
+    @lru_cache
     def get_build_scripts(self):
         """
         Ordered list of shell script snippets to build the base image.
@@ -360,7 +360,7 @@ class BuildPack:
 
         return []
 
-    @lru_cache()
+    @lru_cache
     def get_preassemble_script_files(self):
         """
         Dict of files to be copied to the container image for use in preassembly.
@@ -374,7 +374,7 @@ class BuildPack:
         """
         return {}
 
-    @lru_cache()
+    @lru_cache
     def get_preassemble_scripts(self):
         """
         Ordered list of shell snippets to build an image for this repository.
@@ -391,7 +391,7 @@ class BuildPack:
         """
         return []
 
-    @lru_cache()
+    @lru_cache
     def get_assemble_scripts(self):
         """
         Ordered list of shell script snippets to build the repo into the image.
@@ -418,7 +418,7 @@ class BuildPack:
         """
         return []
 
-    @lru_cache()
+    @lru_cache
     def get_post_build_scripts(self):
         """
         An ordered list of executable scripts to execute after build.
@@ -431,7 +431,7 @@ class BuildPack:
         """
         return []
 
-    @lru_cache()
+    @lru_cache
     def get_start_script(self):
         """
         The path to a script to be executed at container start up.
@@ -672,14 +672,14 @@ class BuildPack:
 
 
 class BaseImage(BuildPack):
-    @lru_cache()
+    @lru_cache
     def get_build_env(self):
         """Return env directives required for build"""
         return [
             ("APP_BASE", "/srv"),
         ]
 
-    @lru_cache()
+    @lru_cache
     def get_env(self):
         """Return env directives to be set after build"""
         return []
@@ -687,7 +687,7 @@ class BaseImage(BuildPack):
     def detect(self):
         return True
 
-    @lru_cache()
+    @lru_cache
     def get_preassemble_scripts(self):
         scripts = []
         try:
@@ -727,19 +727,19 @@ class BaseImage(BuildPack):
 
         return scripts
 
-    @lru_cache()
+    @lru_cache
     def get_assemble_scripts(self):
         """Return directives to run after the entire repository has been added to the image"""
         return []
 
-    @lru_cache()
+    @lru_cache
     def get_post_build_scripts(self):
         post_build = self.binder_path("postBuild")
         if os.path.exists(post_build):
             return [post_build]
         return []
 
-    @lru_cache()
+    @lru_cache
     def get_start_script(self):
         start = self.binder_path("start")
         if os.path.exists(start):

--- a/repo2docker/buildpacks/conda/__init__.py
+++ b/repo2docker/buildpacks/conda/__init__.py
@@ -46,7 +46,7 @@ class CondaBuildPack(BaseImage):
             return "linux-aarch64"
         raise ValueError(f"Unknown platform {self.platform}")
 
-    @lru_cache()
+    @lru_cache
     def get_build_env(self):
         """Return environment variables to be set.
 
@@ -90,13 +90,13 @@ class CondaBuildPack(BaseImage):
             env.append(("KERNEL_PYTHON_PREFIX", "${NB_PYTHON_PREFIX}"))
         return env
 
-    @lru_cache()
+    @lru_cache
     def get_env(self):
         """Make kernel env the default for `conda install`"""
         env = super().get_env() + [("CONDA_DEFAULT_ENV", "${KERNEL_PYTHON_PREFIX}")]
         return env
 
-    @lru_cache()
+    @lru_cache
     def get_path(self):
         """Return paths (including conda environment path) to be added to
         the PATH environment variable.
@@ -111,7 +111,7 @@ class CondaBuildPack(BaseImage):
         path.append("${NPM_DIR}/bin")
         return path
 
-    @lru_cache()
+    @lru_cache
     def get_build_scripts(self):
         """
         Return series of build-steps common to all Python 3 repositories.
@@ -149,7 +149,7 @@ class CondaBuildPack(BaseImage):
 
     major_pythons = {"2": "2.7", "3": "3.10"}
 
-    @lru_cache()
+    @lru_cache
     def get_build_script_files(self):
         """
         Dict of files to be copied to the container image for use in building.
@@ -374,7 +374,7 @@ class CondaBuildPack(BaseImage):
             self.kernel_env_cutoff_version
         )
 
-    @lru_cache()
+    @lru_cache
     def get_preassemble_script_files(self):
         """preassembly only requires environment.yml
 
@@ -388,7 +388,7 @@ class CondaBuildPack(BaseImage):
                 assemble_files[environment_yml] = environment_yml
         return assemble_files
 
-    @lru_cache()
+    @lru_cache
     def get_env_scripts(self):
         """Return series of build-steps specific to this source repository."""
         scripts = []
@@ -455,14 +455,14 @@ class CondaBuildPack(BaseImage):
             ]
         return scripts
 
-    @lru_cache()
+    @lru_cache
     def get_preassemble_scripts(self):
         scripts = super().get_preassemble_scripts()
         if self._should_preassemble_env:
             scripts.extend(self.get_env_scripts())
         return scripts
 
-    @lru_cache()
+    @lru_cache
     def get_assemble_scripts(self):
         scripts = super().get_assemble_scripts()
         if not self._should_preassemble_env:

--- a/repo2docker/buildpacks/julia/julia_project.py
+++ b/repo2docker/buildpacks/julia/julia_project.py
@@ -69,7 +69,7 @@ class JuliaProjectTomlBuildPack(PythonBuildPack):
             raise RuntimeError("Failed to find a matching Julia version: {compat}")
         return match
 
-    @lru_cache()
+    @lru_cache
     def get_build_env(self):
         """Get additional environment settings for Julia and Jupyter
 
@@ -112,11 +112,11 @@ class JuliaProjectTomlBuildPack(PythonBuildPack):
         else:
             return "${REPO_DIR}"
 
-    @lru_cache()
+    @lru_cache
     def get_env(self):
         return super().get_env() + [("JULIA_PROJECT", self.project_dir)]
 
-    @lru_cache()
+    @lru_cache
     def get_path(self):
         """Adds path to Julia binaries to user's PATH.
 
@@ -127,7 +127,7 @@ class JuliaProjectTomlBuildPack(PythonBuildPack):
         """
         return super().get_path() + ["${JULIA_PATH}/bin"]
 
-    @lru_cache()
+    @lru_cache
     def get_build_scripts(self):
         """
         Return series of build-steps common to "ALL" Julia repositories
@@ -156,7 +156,7 @@ class JuliaProjectTomlBuildPack(PythonBuildPack):
             ),
         ]
 
-    @lru_cache()
+    @lru_cache
     def get_assemble_scripts(self):
         """
         Return series of build-steps specific to "this" Julia repository

--- a/repo2docker/buildpacks/nix/__init__.py
+++ b/repo2docker/buildpacks/nix/__init__.py
@@ -9,12 +9,12 @@ from ..base import BaseImage
 class NixBuildPack(BaseImage):
     """A nix Package Manager BuildPack"""
 
-    @lru_cache()
+    @lru_cache
     def get_path(self):
         """Return paths to be added to PATH environemnt variable"""
         return super().get_path() + ["/home/${NB_USER}/.nix-profile/bin"]
 
-    @lru_cache()
+    @lru_cache
     def get_env(self):
         """Ordered list of environment variables to be set for this image"""
 
@@ -24,7 +24,7 @@ class NixBuildPack(BaseImage):
             ("GIT_SSL_CAINFO", "/etc/ssl/certs/ca-certificates.crt"),
         ]
 
-    @lru_cache()
+    @lru_cache
     def get_build_scripts(self):
         """
         Return series of build-steps common to all nix repositories.
@@ -60,7 +60,7 @@ class NixBuildPack(BaseImage):
             ),
         ]
 
-    @lru_cache()
+    @lru_cache
     def get_build_script_files(self):
         """Dict of files to be copied to the container image for use in building"""
         return {
@@ -68,7 +68,7 @@ class NixBuildPack(BaseImage):
             "nix/nix-shell-wrapper": "/usr/local/bin/nix-shell-wrapper",
         }
 
-    @lru_cache()
+    @lru_cache
     def get_assemble_scripts(self):
         """Return series of build-steps specific to this source repository."""
         return super().get_assemble_scripts() + [
@@ -82,7 +82,7 @@ class NixBuildPack(BaseImage):
             )
         ]
 
-    @lru_cache()
+    @lru_cache
     def get_start_script(self):
         """The path to a script to be executed as ENTRYPOINT"""
         # the shell wrapper script duplicates the behaviour of other buildpacks

--- a/repo2docker/buildpacks/pipfile/__init__.py
+++ b/repo2docker/buildpacks/pipfile/__init__.py
@@ -80,7 +80,7 @@ class PipfileBuildPack(CondaBuildPack):
             )
             return self._python_version
 
-    @lru_cache()
+    @lru_cache
     def get_preassemble_script_files(self):
         """Return files needed for preassembly"""
         files = super().get_preassemble_script_files()
@@ -90,7 +90,7 @@ class PipfileBuildPack(CondaBuildPack):
                 files[path] = path
         return files
 
-    @lru_cache()
+    @lru_cache
     def get_preassemble_scripts(self):
         """scripts to run prior to staging the repo contents"""
         scripts = super().get_preassemble_scripts()
@@ -108,7 +108,7 @@ class PipfileBuildPack(CondaBuildPack):
         )
         return scripts
 
-    @lru_cache()
+    @lru_cache
     def get_assemble_scripts(self):
         """Return series of build-steps specific to this repository."""
         # If we have either Pipfile.lock, Pipfile, or runtime.txt declare the

--- a/repo2docker/buildpacks/python/__init__.py
+++ b/repo2docker/buildpacks/python/__init__.py
@@ -98,7 +98,7 @@ class PythonBuildPack(CondaBuildPack):
         # allow assembly from subset
         return True
 
-    @lru_cache()
+    @lru_cache
     def get_preassemble_script_files(self):
         assemble_files = super().get_preassemble_script_files()
         for name in ("requirements.txt", "requirements3.txt"):
@@ -107,7 +107,7 @@ class PythonBuildPack(CondaBuildPack):
                 assemble_files[requirements_txt] = requirements_txt
         return assemble_files
 
-    @lru_cache()
+    @lru_cache
     def get_preassemble_scripts(self):
         """Return scripts to run before adding the full repository"""
         scripts = super().get_preassemble_scripts()
@@ -115,7 +115,7 @@ class PythonBuildPack(CondaBuildPack):
             scripts.extend(self._get_pip_scripts())
         return scripts
 
-    @lru_cache()
+    @lru_cache
     def get_assemble_scripts(self):
         """Return series of build steps that require the full repository"""
         # If we have a runtime.txt & that's set to python-2.7,

--- a/repo2docker/buildpacks/r.py
+++ b/repo2docker/buildpacks/r.py
@@ -146,7 +146,7 @@ class RBuildPack(PythonBuildPack):
                 self._runtime = f"r-{str(self._checkpoint_date)}"
             return True
 
-    @lru_cache()
+    @lru_cache
     def get_env(self):
         """
         Set custom env vars needed for RStudio to load
@@ -161,7 +161,7 @@ class RBuildPack(PythonBuildPack):
             ("LD_LIBRARY_PATH", "${R_HOME}/lib:${LD_LIBRARY_PATH}"),
         ]
 
-    @lru_cache()
+    @lru_cache
     def get_path(self):
         """
         Return paths to be added to the PATH environment variable.
@@ -171,7 +171,7 @@ class RBuildPack(PythonBuildPack):
         """
         return super().get_path() + ["/usr/lib/rstudio-server/bin/"]
 
-    @lru_cache()
+    @lru_cache
     def get_build_env(self):
         """
         Return environment variables to be set.
@@ -185,7 +185,7 @@ class RBuildPack(PythonBuildPack):
             ("R_LIBS_USER", "${APP_BASE}/rlibs")
         ]
 
-    @lru_cache()
+    @lru_cache
     def get_packages(self):
         """
         Return list of packages to be installed.
@@ -204,7 +204,7 @@ class RBuildPack(PythonBuildPack):
 
         return super().get_packages().union(packages)
 
-    @lru_cache()
+    @lru_cache
     def get_rspm_snapshot_url(self, snapshot_date, max_days_prior=7):
         for i in range(max_days_prior):
             snapshots = requests.post(
@@ -232,7 +232,7 @@ class RBuildPack(PythonBuildPack):
             )
         )
 
-    @lru_cache()
+    @lru_cache
     def get_devtools_snapshot_url(self):
         """
         Return url of snapshot to use for getting devtools install
@@ -249,7 +249,7 @@ class RBuildPack(PythonBuildPack):
         # appropriate binary packages without having to hard code version names here.
         return "https://packagemanager.posit.co/all/__linux__/${VERSION_CODENAME}/2022-06-03+Y3JhbiwyOjQ1MjYyMTU7RkM5ODcwN0M"
 
-    @lru_cache()
+    @lru_cache
     def get_build_scripts(self):
         """
         Return series of build-steps common to all R repositories
@@ -361,7 +361,7 @@ class RBuildPack(PythonBuildPack):
 
         return super().get_build_scripts() + scripts
 
-    @lru_cache()
+    @lru_cache
     def get_preassemble_script_files(self):
         files = super().get_preassemble_script_files()
         installR_path = self.binder_path("install.R")
@@ -370,7 +370,7 @@ class RBuildPack(PythonBuildPack):
 
         return files
 
-    @lru_cache()
+    @lru_cache
     def get_preassemble_scripts(self):
         """Install contents of install.R
 
@@ -396,7 +396,7 @@ class RBuildPack(PythonBuildPack):
 
         return super().get_preassemble_scripts() + scripts
 
-    @lru_cache()
+    @lru_cache
     def get_assemble_scripts(self):
         """Install the dependencies of or the repository itself"""
         assemble_scripts = super().get_assemble_scripts()

--- a/repo2docker/semver.py
+++ b/repo2docker/semver.py
@@ -30,7 +30,7 @@ def str_to_version(vstr):
     return tuple([int(n) for n in vstr.split(".")])
 
 
-@lru_cache()
+@lru_cache
 def parse_version(vstr):
     """Convert a simple 'x[.y[.z]]' version string to a comparable VersionInfo
 
@@ -62,7 +62,7 @@ def patch(v):
     return v[2] if len(v) >= 3 else 0
 
 
-@lru_cache()
+@lru_cache
 def create_semver_matcher(constraint_str):
     """Create a matcher that can be used to match version tuples
 

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ setup(
         "toml",
         "traitlets",
     ],
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     author="Project Jupyter Contributors",
     author_email="jupyter@googlegroups.com",
     url="https://repo2docker.readthedocs.io/en/latest/",

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ setup(
         "toml",
         "traitlets",
     ],
-    python_requires=">=3.6",
+    python_requires=">=3.8",
     author="Project Jupyter Contributors",
     author_email="jupyter@googlegroups.com",
     url="https://repo2docker.readthedocs.io/en/latest/",


### PR DESCRIPTION
We're making a breaking release:
https://github.com/jupyterhub/repo2docker/pull/1402
so we can use the opportunity to add other breaking changes. This only affects the Python version required to run repo2docker, it doesn't change the Python versions supported in environments.
