### PR TITLE
Simulate json output from docker buildx build

### DIFF
--- a/repo2docker/docker.py
+++ b/repo2docker/docker.py
@@ -58,7 +58,7 @@ class DockerEngine(ContainerEngine):
     https://docker-py.readthedocs.io/en/4.2.0/api.html#module-docker.api.build
     """
 
-    string_output = True
+    string_output = False
 
     extra_init_args = Dict(
         {},
@@ -141,12 +141,18 @@ class DockerEngine(ContainerEngine):
 
                 args += [d]
 
-                yield from execute_cmd(args, True)
+                for line in execute_cmd(args, True):
+                    # Simulate structured JSON output from buildx build, since we
+                    # do get structured json output from pushing and running
+                    yield {"stream": line}
         else:
             # Assume 'path' is passed in
             args += [path]
 
-            yield from execute_cmd(args, True)
+            for line in execute_cmd(args, True):
+                # Simulate structured JSON output from buildx build, since we
+                # do get structured json output from pushing and running
+                yield {"stream": line}
 
     def images(self):
         images = self._apiclient.images()


### PR DESCRIPTION
We still use the docker python api to push images, and to run. So we need to set string_output to false, and simulate the json output on buildx. Alternatively we could completely get rid of the python API, but that's a much bigger lift (especially around registry credentials) that I don't want us to do right now.

Without this, push progress is reported as raw bytes in the binderhub UI
