### PR TITLE
[MRG] Disable bash trace output in conda activation script

### DIFF
--- a/repo2docker/buildpacks/conda/activate-conda.sh
+++ b/repo2docker/buildpacks/conda/activate-conda.sh
@@ -1,4 +1,4 @@
-set -ex
+set -e
 
 # Setup conda
 CONDA_PROFILE="${CONDA_DIR}/etc/profile.d/conda.sh"
@@ -35,4 +35,4 @@ else
     mamba activate ${NB_PYTHON_PREFIX}
 fi
 
-set +ex
+set +e


### PR DESCRIPTION
Resolves #1424 

Remove `-x` to be less spammy. Retain `-e` to exit on errors! (reference: https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html)

<!--

Our guide to getting a PR merged https://repo2docker.readthedocs.io/en/latest/contributing/contributing.html#guidelines-to-getting-a-pull-request-merged.

About to propose a big change? Read https://repo2docker.readthedocs.io/en/latest/contributing/contributing.html#process-for-making-a-contribution to maximise the chances of it getting merged quickly.

-->
