### PR TITLE
Move `runtime.txt` parsing into base class

### DIFF
--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased breaking changes
+
+`RBuildPack.runtime` previously returned the contents of `runtime.txt` as a string.
+It has been replaced by `BuildPack.runtime` which returns a tuple `(name, version, date)`.
+
 ## 2024.07.0
 
 ([full changelog](https://github.com/jupyterhub/repo2docker/compare/2024.03.0...2024.07.0))

--- a/repo2docker/buildpacks/base.py
+++ b/repo2docker/buildpacks/base.py
@@ -759,6 +759,11 @@ class BaseImage(BuildPack):
 
         Returns (runtime, version, date), tuple components may be None.
         Returns (None, None, None) if runtime.txt not found.
+
+        Supported formats:
+          name-version
+          name-version-yyyy-mm-dd
+          name-yyyy-mm-dd
         """
         if hasattr(self, "_runtime"):
             return self._runtime
@@ -776,15 +781,19 @@ class BaseImage(BuildPack):
         version = None
         date = None
 
-        parts = runtime_txt.split("-", 2)
-        if len(parts) > 0 and parts[0]:
-            name = parts[0]
-        if len(parts) > 1 and parts[1]:
+        parts = runtime_txt.split("-")
+        if len(parts) not in (2, 4, 5) or any(not (p) for p in parts):
+            raise ValueError(f"Invalid runtime.txt: {runtime_txt}")
+
+        name = parts[0]
+
+        if len(parts) in (2, 5):
             version = parts[1]
-        if len(parts) > 2 and parts[2]:
-            date = parts[2]
+
+        if len(parts) in (4, 5):
+            date = "-".join(parts[-3:])
             if not re.match(r"\d\d\d\d-\d\d-\d\d", date):
-                raise ValueError(f"Invalid date, expected YYYY-MM-DD: {date}")
+                raise ValueError(f"Invalid runtime.txt date: {date}")
             date = datetime.datetime.fromisoformat(date).date()
 
         self._runtime = (name, version, date)

--- a/repo2docker/buildpacks/base.py
+++ b/repo2docker/buildpacks/base.py
@@ -753,7 +753,7 @@ class BaseImage(BuildPack):
         return None
 
     @property
-    def runtime_info(self):
+    def runtime(self):
         """
         Return parsed contents of runtime.txt
 
@@ -772,13 +772,13 @@ class BaseImage(BuildPack):
         except FileNotFoundError:
             return self._runtime
 
-        runtime = None
+        name = None
         version = None
         date = None
 
         parts = runtime_txt.split("-", 2)
         if len(parts) > 0 and parts[0]:
-            runtime = parts[0]
+            name = parts[0]
         if len(parts) > 1 and parts[1]:
             version = parts[1]
         if len(parts) > 2 and parts[2]:
@@ -787,5 +787,5 @@ class BaseImage(BuildPack):
                 raise ValueError(f"Invalid date, expected YYYY-MM-DD: {date}")
             date = datetime.datetime.fromisoformat(date).date()
 
-        self._runtime = (runtime, version, date)
+        self._runtime = (name, version, date)
         return self._runtime

--- a/repo2docker/buildpacks/base.py
+++ b/repo2docker/buildpacks/base.py
@@ -1,3 +1,4 @@
+import datetime
 import hashlib
 import io
 import logging
@@ -750,3 +751,41 @@ class BaseImage(BuildPack):
             # the only path evaluated at container start time rather than build time
             return os.path.join("${REPO_DIR}", start)
         return None
+
+    @property
+    def runtime_info(self):
+        """
+        Return parsed contents of runtime.txt
+
+        Returns (runtime, version, date), tuple components may be None.
+        Returns (None, None, None) if runtime.txt not found.
+        """
+        if hasattr(self, "_runtime"):
+            return self._runtime
+
+        self._runtime = (None, None, None)
+
+        runtime_path = self.binder_path("runtime.txt")
+        try:
+            with open(runtime_path) as f:
+                runtime_txt = f.read().strip()
+        except FileNotFoundError:
+            return self._runtime
+
+        runtime = None
+        version = None
+        date = None
+
+        parts = runtime_txt.split("-", 2)
+        if len(parts) > 0 and parts[0]:
+            runtime = parts[0]
+        if len(parts) > 1 and parts[1]:
+            version = parts[1]
+        if len(parts) > 2 and parts[2]:
+            date = parts[2]
+            if not re.match(r"\d\d\d\d-\d\d-\d\d", date):
+                raise ValueError(f"Invalid date, expected YYYY-MM-DD: {date}")
+            date = datetime.datetime.fromisoformat(date).date()
+
+        self._runtime = (runtime, version, date)
+        return self._runtime

--- a/repo2docker/buildpacks/pipfile/__init__.py
+++ b/repo2docker/buildpacks/pipfile/__init__.py
@@ -187,8 +187,8 @@ class PipfileBuildPack(CondaBuildPack):
     def detect(self):
         """Check if current repo should be built with the Pipfile buildpack."""
         # first make sure python is not explicitly unwanted
-        runtime = self.runtime_info[0]
-        if runtime and runtime != "python":
+        name = self.runtime[0]
+        if name and name != "python":
             return False
 
         pipfile = self.binder_path("Pipfile")

--- a/repo2docker/buildpacks/pipfile/__init__.py
+++ b/repo2docker/buildpacks/pipfile/__init__.py
@@ -187,12 +187,9 @@ class PipfileBuildPack(CondaBuildPack):
     def detect(self):
         """Check if current repo should be built with the Pipfile buildpack."""
         # first make sure python is not explicitly unwanted
-        runtime_txt = self.binder_path("runtime.txt")
-        if os.path.exists(runtime_txt):
-            with open(runtime_txt) as f:
-                runtime = f.read().strip()
-            if not runtime.startswith("python-"):
-                return False
+        runtime = self.runtime_info[0]
+        if runtime and runtime != "python":
+            return False
 
         pipfile = self.binder_path("Pipfile")
         pipfile_lock = self.binder_path("Pipfile.lock")

--- a/repo2docker/buildpacks/python/__init__.py
+++ b/repo2docker/buildpacks/python/__init__.py
@@ -15,9 +15,9 @@ class PythonBuildPack(CondaBuildPack):
         if hasattr(self, "_python_version"):
             return self._python_version
 
-        runtime, version, _ = self.runtime_info
+        name, version, _ = self.runtime
 
-        if runtime != "python" or not version:
+        if name != "python" or not version:
             # Either not specified, or not a Python runtime (e.g. R, which subclasses this)
             # use the default Python
             self._python_version = self.major_pythons["3"]
@@ -136,8 +136,9 @@ class PythonBuildPack(CondaBuildPack):
         requirements_txt = self.binder_path("requirements.txt")
         setup_py = "setup.py"
 
-        if self.runtime_info[0]:
-            return self.runtime_info[0] == "python"
+        name = self.runtime[0]
+        if name:
+            return name == "python"
         if not self.binder_dir and os.path.exists(setup_py):
             return True
         return os.path.exists(requirements_txt)

--- a/repo2docker/buildpacks/r.py
+++ b/repo2docker/buildpacks/r.py
@@ -46,28 +46,6 @@ class RBuildPack(PythonBuildPack):
     """
 
     @property
-    def runtime(self):
-        """
-        Return contents of runtime.txt if it exists, '' otherwise
-
-        Deprecated, use `runtime_info` instead.
-        """
-        warnings.warn(
-            "`{self.__class__.__name__}.runtime` is deprecated. Use `runtime_info` instead",
-            DeprecationWarning,
-        )
-
-        if not hasattr(self, "_runtime"):
-            runtime_path = self.binder_path("runtime.txt")
-            try:
-                with open(runtime_path) as f:
-                    self._runtime = f.read().strip()
-            except FileNotFoundError:
-                self._runtime = ""
-
-        return self._runtime
-
-    @property
     def r_version(self):
         """Detect the R version for a given `runtime.txt`
 
@@ -97,7 +75,7 @@ class RBuildPack(PythonBuildPack):
         r_version = version_map["4.2"]
 
         if not hasattr(self, "_r_version"):
-            runtime, version, date = self.runtime_info
+            _, version, date = self.runtime
             # If runtime.txt is not set, or if it isn't of the form r-<version>-<yyyy>-<mm>-<dd>,
             # we don't use any of it in determining r version and just use the default
             if version and date:
@@ -123,8 +101,8 @@ class RBuildPack(PythonBuildPack):
         Returns '' if no date is specified
         """
         if not hasattr(self, "_checkpoint_date"):
-            runtime, version, date = self.runtime_info
-            if runtime == "r" and date:
+            name, version, date = self.runtime
+            if name == "r" and date:
                 self._checkpoint_date = date
             else:
                 self._checkpoint_date = False

--- a/tests/unit/test_buildpack.py
+++ b/tests/unit/test_buildpack.py
@@ -64,7 +64,7 @@ def test_unsupported_python(tmpdir, python_version, base_image):
         ("a_b/c-0.0.1-2025-06-22", ("a_b/c", "0.0.1", date(2025, 6, 22))),
     ],
 )
-def test_runtime_txt(tmpdir, runtime_txt, expected, base_image):
+def test_runtime(tmpdir, runtime_txt, expected, base_image):
     tmpdir.chdir()
 
     if runtime_txt is not None:
@@ -72,4 +72,4 @@ def test_runtime_txt(tmpdir, runtime_txt, expected, base_image):
             f.write(runtime_txt)
 
     base = BaseImage(base_image)
-    assert base.runtime_info == expected
+    assert base.runtime == expected

--- a/tests/unit/test_buildpack.py
+++ b/tests/unit/test_buildpack.py
@@ -57,10 +57,9 @@ def test_unsupported_python(tmpdir, python_version, base_image):
     "runtime_txt, expected",
     [
         (None, (None, None, None)),
-        ("", (None, None, None)),
-        ("abc", ("abc", None, None)),
         ("abc-001", ("abc", "001", None)),
         ("abc-001-2025-06-22", ("abc", "001", date(2025, 6, 22))),
+        ("abc-2025-06-22", ("abc", None, date(2025, 6, 22))),
         ("a_b/c-0.0.1-2025-06-22", ("a_b/c", "0.0.1", date(2025, 6, 22))),
     ],
 )
@@ -73,3 +72,24 @@ def test_runtime(tmpdir, runtime_txt, expected, base_image):
 
     base = BaseImage(base_image)
     assert base.runtime == expected
+
+
+@pytest.mark.parametrize(
+    "runtime_txt",
+    [
+        "",
+        "abc",
+        "abc-001-25-06-22",
+    ],
+)
+def test_invalid_runtime(tmpdir, runtime_txt, base_image):
+    tmpdir.chdir()
+
+    if runtime_txt is not None:
+        with open("runtime.txt", "w") as f:
+            f.write(runtime_txt)
+
+    base = BaseImage(base_image)
+
+    with pytest.raises(ValueError, match=r"^Invalid runtime.txt.*"):
+        base.runtime


### PR DESCRIPTION
There's a discussion somewhere (I can't remember where) about using https://github.com/astrofrog/pypi-timemachine or similar so Python packages can be installed as if `pip` were run in the past, similar to R. If we do this we should define the cutoff date for Python in the same way as for R, which is to use `runtime.txt`.

Something to consider is we haven't formally defined what `runtime.txt` contains.

Our docs state it should be one of:
- `name-version-yyyy-mm-dd`: (`r-<RVERSION>-<YYYY>-<MM>-<DD>`)
- `name-version`: (`python-x.y`)
https://github.com/jupyterhub/repo2docker/blob/e795060aec3555a6203ed79c3676765fb3f3b850/docs/source/config_files.rst?plain=1#L201-L207

Our tests say it can also be:
- name-yyyy-mm-dd
https://github.com/jupyterhub/repo2docker/blob/e795060aec3555a6203ed79c3676765fb3f3b850/tests/unit/test_r.py#L38

This PR handles all three formats. I've made a breaking change and redefined the existing `.runtime` property instead of creating a new one to avoid leaving an unused `.runtime` property that may cause confusion in the future.