### PR TITLE
build: migrate from setup.py to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,80 @@
+[build-system]
+requires = ["setuptools>=61.0", "wheel", "setuptools-scm"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "jupyter-repo2docker"
+dynamic = ["version"]
+description = "Repo2docker: Turn code repositories into Jupyter enabled Docker Images"
+readme = "README.md"
+license = {text = "BSD"}
+authors = [
+    {name = "Project Jupyter Contributors", email = "jupyter@googlegroups.com"}
+]
+maintainers = [
+    {name = "Project Jupyter Contributors", email = "jupyter@googlegroups.com"}
+]
+keywords = ["reproducible", "science", "environments", "docker"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "Intended Audience :: System Administrators",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: BSD License",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Scientific/Engineering",
+    "Topic :: Software Development",
+    "Topic :: System :: Systems Administration",
+]
+requires-python = ">=3.9"
+dependencies = [
+    "chardet",
+    "docker!=5.0.0",
+    "entrypoints",
+    "escapism",
+    "iso8601",
+    "jinja2",
+    "python-json-logger",
+    "requests",
+    "ruamel.yaml>=0.15",
+    "semver",
+    "toml",
+    "traitlets",
+]
+
+[project.urls]
+Homepage = "https://repo2docker.readthedocs.io/en/latest/"
+Documentation = "https://repo2docker.readthedocs.io"
+Funding = "https://jupyter.org/about"
+Source = "https://github.com/jupyterhub/repo2docker/"
+Tracker = "https://github.com/jupyterhub/repo2docker/issues"
+
+[project.scripts]
+jupyter-repo2docker = "repo2docker.__main__:main"
+repo2docker = "repo2docker.__main__:main"
+
+[project.entry-points."repo2docker.engines"]
+docker = "repo2docker.docker:DockerEngine"
+
+[tool.setuptools]
+include-package-data = true
+
+[tool.setuptools.packages.find]
+where = ["."]
+
+
+[tool.wheel]
+universal = 1
+
+
+[tool.setuptools_scm]
+# 这个配置会让 setuptools-scm 自动创建一个 my_awesome_project/_version.py 文件，
+# 并在里面写入版本号。这样你的项目代码在运行时可以通过 my_awesome_project._version
+# 来获取自身的版本。
+write_to = "repo2docker/_version.py"

--- a/repo2docker/__init__.py
+++ b/repo2docker/__init__.py
@@ -1,9 +1,5 @@
-from ._version import get_versions
-
-__version__ = get_versions()["version"]
-del get_versions
-
-from . import _version
+from ._version import __version__
 from .app import Repo2Docker
 
-__version__ = _version.get_versions()["version"]
+# You can add this if you want an __all__ variable to control imports
+__all__ = ["__version__", "Repo2Docker"]

--- a/test_setuptools.py
+++ b/test_setuptools.py
@@ -1,0 +1,17 @@
+
+from setuptools.config.pyprojecttoml import read_configuration
+import tomllib
+if __name__ == '__main__':
+    try:
+        with open('pyproject.toml', 'rb') as f:
+                tomllib.load(f)
+        print('✅ TOML语法正确')
+    except Exception as e:
+        print(f'❌ TOML语法错误: {e}')
+        
+    try:
+        config = read_configuration('pyproject.toml')
+        print('✅ 配置文件语法正确')
+        print('项目名称:', config.get('name'))
+    except Exception as e:
+        print('❌ 配置错误:', e)


### PR DESCRIPTION
- Replace legacy setup.py with standardized pyproject.toml
- Follow PEP 517 (build system) and PEP 621 (metadata)
- Use setuptools as build backend with modern configuration
- add pyproject.toml file、test_setuptools.py  file (a test scripts of toml)、Modify  __init__.py  file
This improves dependency management, IDE support, and aligns with current Python packaging standards.