### PR TITLE
Always call `ContainerEngine.build()` when `push`ing

### DIFF
--- a/repo2docker/app.py
+++ b/repo2docker/app.py
@@ -733,7 +733,10 @@ class Repo2Docker(Application):
         try:
             self.fetch(self.repo, self.ref, checkout_path)
 
-            if self.find_image():
+            if self.find_image() and not self.push:
+                # If push is requested we don't have a general way to query the registry.
+                # ContainerEngine.build() also handles pushing, so always "build" and
+                # rely on the implementation to decide whether to rebuild.
                 self.log.info(
                     f"Reusing existing image ({self.output_image_spec}), not building."
                 )


### PR DESCRIPTION
This is so that if the image is built but not pushed it will still be pushed

The default `DockerEngine.build()` will always rebuild, it's not possible to only push.

Closes https://github.com/jupyterhub/repo2docker/issues/1463