### PR TITLE
Fix the HydroShare download url

### DIFF
--- a/repo2docker/contentproviders/hydroshare.py
+++ b/repo2docker/contentproviders/hydroshare.py
@@ -66,9 +66,8 @@ class Hydroshare(DoiProvider):
         # bag downloads are prepared on demand and may need some time
         conn = self.urlopen(bag_url)
         total_wait_time = 0
-        while (
-            conn.status_code == 200
-            and not conn.url.startswith(f"https://s3.hydroshare.org/bags/{resource_id}.zip")
+        while conn.status_code == 200 and not conn.url.startswith(
+            f"https://s3.hydroshare.org/bags/{resource_id}.zip"
         ):
             wait_time = 10
             total_wait_time += wait_time

--- a/tests/unit/contentproviders/test_hydroshare.py
+++ b/tests/unit/contentproviders/test_hydroshare.py
@@ -106,8 +106,10 @@ def test_fetch_bag():
             Hydroshare,
             "urlopen",
             side_effect=[
-                MockResponse("https://www.hydroshare.org/django_s3/download/bags/123456789.zip",
-                             200),
+                MockResponse(
+                    "https://www.hydroshare.org/django_s3/download/bags/123456789.zip",
+                    200,
+                ),
                 MockResponse("https://s3.hydroshare.org/bags/123456789.zip", 200),
             ],
         ):


### PR DESCRIPTION
HydroShare no longer uses irods as a fileserver and now uses S3. The S3 server serves the downloads and this broke integration with repo2docker.

I have verified the changes work with several HydroShare resources. I also updated the unit tests around HydroShare as best as I could. There are 2 tests in `tests/unit/contentproviders/test_hydroshare.py` that fail. These tests fail because doi.org is blocking the requests to `https://doi.org/api/handles/` to resolve the doi. I observed this behavior when making requests locally using the requests library and curl. I was only able to get a response from `doi.org` when I made the request through my web browser.

```
FAILED tests/unit/contentproviders/test_hydroshare.py::test_content_id - requests.exceptions.ConnectionError: ('Connection aborted.', ConnectionResetError(54, 'Connection reset by peer'))
FAILED tests/unit/contentproviders/test_hydroshare.py::test_detect_hydroshare - requests.exceptions.ConnectionError: ('Connection aborted.', ConnectionResetError(54, 'Connection reset by peer'))
```

<!--

Our guide to getting a PR merged https://repo2docker.readthedocs.io/en/latest/contributing/contributing.html#guidelines-to-getting-a-pull-request-merged.

About to propose a big change? Read https://repo2docker.readthedocs.io/en/latest/contributing/contributing.html#process-for-making-a-contribution to maximise the chances of it getting merged quickly.

-->
