### PR TITLE
Don't error out if there's no disk space left when writing the logs

### DIFF
--- a/repo2docker/buildpacks/repo2docker-entrypoint
+++ b/repo2docker/buildpacks/repo2docker-entrypoint
@@ -45,7 +45,7 @@ def main():
             break
     # raise Exception if log_file could not be set
     if log_file is None:
-        raise Exception("Could not open '.jupyter-server-log.txt' log file " )
+        raise Exception("Could not open '.jupyter-server-log.txt' log file")
 
     # build the command
     # like `exec "$@"`
@@ -74,23 +74,27 @@ def main():
     for signum in SIGNALS:
         signal.signal(signum, relay_signal)
 
-    enospc = {
-        sys.stdout.buffer: False,
-        log_file: False
+    # keep a record of the output streams that ran out space
+    writable = {
+        sys.stdout.buffer: True,
+        log_file: True
     }
 
     # tee output from child to both our stdout and the log file
     def tee(chunk):
-        """Tee output from child to the log file"""
+        """Tee output from child to both our stdout and the log file"""
         for f in [sys.stdout.buffer, log_file]:
-            if not enospc[f]:
+            if writable[f]:
                 try:
                     f.write(chunk)
                     f.flush()
                 except OSError as e:
                     if e.errno == errno.ENOSPC:
-                        enospc[f] = True
+                        # mark the stream as not writable anymore
+                        writable[f] = False
                         continue
+                    else:
+                        raise
 
     # make stdout pipe non-blocking
     # this means child.stdout.read(nbytes)
@@ -117,6 +121,8 @@ def main():
     while chunk:
         tee(chunk)
         chunk = child.stdout.read()
+
+    log_file.close()
 
     # make our returncode match the child's returncode
     sys.exit(child.returncode)


### PR DESCRIPTION
<!--

Our guide to getting a PR merged https://repo2docker.readthedocs.io/en/latest/contributing/contributing.html#guidelines-to-getting-a-pull-request-merged.

About to propose a big change? Read https://repo2docker.readthedocs.io/en/latest/contributing/contributing.html#process-for-making-a-contribution to maximise the chances of it getting merged quickly.

-->
## Context

In https://github.com/2i2c-org/infrastructure/pull/7077 we investigated how we could allow user servers to start even if the respective users have reached their storage quota, i.e. they cannot use more space from the disk where their home directories are mounted to.

The results were that user images built with `repo2docker` action that didn't have a Dockerfile where unable to start because writing the logs failed:
```
Defaulted container "notebook" out of: notebook, block-cloud-metadata (init), block-nfs-access (init)
Activating profile: /srv/conda/etc/profile.d/conda.sh
/srv/conda/envs/notebook/lib/python3.11/subprocess.py:1016: RuntimeWarning: line buffering (buffering=1) isn't supported in binary mode, the default buffer size will be used
  self.stdout = io.open(c2pread, 'rb', bufsize)
INFO: Executing provided command
Traceback (most recent call last):
  File "/usr/local/bin/repo2docker-entrypoint", line 114, in <module>
    main()
  File "/usr/local/bin/repo2docker-entrypoint", line 95, in main
    tee(chunk)
  File "/usr/local/bin/repo2docker-entrypoint", line 81, in tee
    f.flush()
OSError: [Errno 28] No space left on device
```

## Motivation
For context, the motivation is that If they cannot start servers when they reach the quota, they won't be able to delete unneeded files and would need to be unblocked by someone with higher privileges to either bump their quota, or delete unwanted files. 

## What changes

This PR mostly does the same thing, except that if the logs cannot be written to `REPO_DIR` or `cwd` because of lack of space, it will end up writing the logs to `stdout` + `tmp` location or just `stdout` without raising any errors that would stop the servers from starting.