### PR TITLE
Fix lint warnings in simple test Dockerfile

### DIFF
--- a/tests/dockerfile/simple/Dockerfile
+++ b/tests/dockerfile/simple/Dockerfile
@@ -2,11 +2,11 @@ FROM python:3.10
 
 RUN pip install --no-cache notebook
 
-CMD "/bin/sh"
+CMD ["/bin/sh"]
 
 ADD sayhi.sh /usr/local/bin/sayhi.sh
 ADD verify verify
 
 ARG NB_UID
-ENV HOME /tmp
+ENV HOME=/tmp
 USER $NB_UID


### PR DESCRIPTION
This PR fixes two lint warnings in `tests/dockerfile/simple/Dockerfile`:

- **JSONArgsRecommended**: The Dockerfile used shell form  
  `CMD "/bin/sh"`  
  which triggers a warning.  
  Updated to JSON exec form:  
  `CMD ["/bin/sh"]`

- **LegacyKeyValueFormat**: The Dockerfile used `ENV HOME /tmp`  
  which triggers a lint warning.  
  Updated to recommended format:  
  `ENV HOME=/tmp`

These are small cleanups in the test Dockerfile and do not change runtime
behavior of repo2docker. They simply align with Docker best practices and
resolve the linter warnings.

Fixes #1477  
Fixes #1478
