### PR TITLE
Fix typo in pyproject.toml file name

### DIFF
--- a/repo2docker/buildpacks/python/__init__.py
+++ b/repo2docker/buildpacks/python/__init__.py
@@ -155,7 +155,7 @@ class PythonBuildPack(CondaBuildPack):
         if os.path.exists("setup.py"):
             return True
         if os.path.exists("pyproject.toml"):
-            with open("pyproject_toml", "rb") as _pyproject_file:
+            with open("pyproject.toml", "rb") as _pyproject_file:
                 pyproject = tomllib.load(_pyproject_file)
 
             if ("project" in pyproject) and ("build-system" in pyproject):


### PR DESCRIPTION
Closes https://github.com/jupyterhub/repo2docker/issues/1498