### PR TITLE
Fix content provider for Zenodo

### DIFF
--- a/repo2docker/contentproviders/zenodo.py
+++ b/repo2docker/contentproviders/zenodo.py
@@ -41,7 +41,7 @@ class Zenodo(DoiProvider):
                     "https://zenodo.org/records/",
                     "http://zenodo.org/records/",
                     "https://zenodo.org/doi/",
-                    "http://zenodo.org/doi/"
+                    "http://zenodo.org/doi/",
                 ],
                 "api": "https://zenodo.org/api/records/",
                 "files": "links.files",
@@ -75,7 +75,11 @@ class Zenodo(DoiProvider):
 
     def fetch(self, spec, output_dir, yield_output=False):
         """Fetch and unpack a Zenodo record"""
-        record_id = spec["record"]
+        # Simple heuristic until repoproviders is ready.
+        if "." in spec["record"]:
+            record_id = spec["record"].split(".")[1]
+        else:
+            record_id = spec["record"]
         host = spec["host"]
 
         yield f"Fetching Zenodo record {record_id}.\n"

--- a/repo2docker/contentproviders/zenodo.py
+++ b/repo2docker/contentproviders/zenodo.py
@@ -22,7 +22,10 @@ class Zenodo(DoiProvider):
                 "hostname": [
                     "https://sandbox.zenodo.org/record/",
                     "http://sandbox.zenodo.org/record/",
+                    "https://sandbox.zenodo.org/records/",
                     "http://sandbox.zenodo.org/records/",
+                    "https://sandbox.zenodo.org/doi/",
+                    "http://sandbox.zenodo.org/doi/",
                 ],
                 "api": "https://sandbox.zenodo.org/api/records/",
                 "files": "links.files",
@@ -36,6 +39,9 @@ class Zenodo(DoiProvider):
                     "https://zenodo.org/record/",
                     "http://zenodo.org/record/",
                     "https://zenodo.org/records/",
+                    "http://zenodo.org/records/",
+                    "https://zenodo.org/doi/",
+                    "http://zenodo.org/doi/"
                 ],
                 "api": "https://zenodo.org/api/records/",
                 "files": "links.files",

--- a/repo2docker/contentproviders/zenodo.py
+++ b/repo2docker/contentproviders/zenodo.py
@@ -54,6 +54,8 @@ class Zenodo(DoiProvider):
                 "hostname": [
                     "https://data.caltech.edu/records/",
                     "http://data.caltech.edu/records/",
+                    # data.caltech.edu was stripped of the endpoint /record/
+                    # data.caltech.edu was stripped of the endpoint /doi/
                 ],
                 "api": "https://data.caltech.edu/api/record/",
                 "files": "",
@@ -70,16 +72,16 @@ class Zenodo(DoiProvider):
 
         for host in self.hosts:
             if any([url.startswith(s) for s in host["hostname"]]):
-                self.record_id = url.rsplit("/", maxsplit=1)[1]
+                url_basename = url.rsplit("/", maxsplit=1)[1]
+
+                # This is required because some DOI will resolve to /record/ and others to /doi/ endpoint.
+                self.record_id = url_basename.replace("zenodo.", "")
                 return {"record": self.record_id, "host": host}
 
     def fetch(self, spec, output_dir, yield_output=False):
         """Fetch and unpack a Zenodo record"""
         # Simple heuristic until repoproviders is ready.
-        if "." in spec["record"]:
-            record_id = spec["record"].split(".")[1]
-        else:
-            record_id = spec["record"]
+        record_id = spec["record"]
         host = spec["host"]
 
         yield f"Fetching Zenodo record {record_id}.\n"

--- a/tests/unit/contentproviders/test_zenodo.py
+++ b/tests/unit/contentproviders/test_zenodo.py
@@ -14,6 +14,7 @@ from repo2docker.contentproviders import Zenodo
 
 doi_responses = {
     "https://doi.org/10.5281/zenodo.3232985": ("https://zenodo.org/record/3232985"),
+    "https://doi.org/10.5281/zenodo.18553140": ("https://zenodo.org/records/18553140"),
     "https://doi.org/10.22002/d1.1235": ("https://data.caltech.edu/records/1235"),
     "https://doi.org/10.21105/joss.01277": (
         "https://joss.theoj.org/papers/10.21105/joss.01277"
@@ -36,6 +37,14 @@ test_hosts = [
             "https://doi.org/10.5281/zenodo.3232985",
         ],
         {"host": test_zen.hosts[1], "record": "3232985"},
+    ),
+    (
+        [
+            "https://zenodo.org/records/18553140",
+            "10.5281/zenodo.18553140",
+            "https://doi.org/10.5281/zenodo.18553140",
+        ],
+        {"host": test_zen.hosts[1], "record": "zenodo.18553140"},
     ),
     (
         [

--- a/tests/unit/contentproviders/test_zenodo.py
+++ b/tests/unit/contentproviders/test_zenodo.py
@@ -14,7 +14,7 @@ from repo2docker.contentproviders import Zenodo
 
 doi_responses = {
     "https://doi.org/10.5281/zenodo.3232985": ("https://zenodo.org/record/3232985"),
-    "https://doi.org/10.5281/zenodo.18553140": ("https://zenodo.org/records/18553140"),
+    "https://doi.org/10.5281/zenodo.18553140": ("https://zenodo.org/doi/10.5281/zenodo.18553140"),
     "https://doi.org/10.22002/d1.1235": ("https://data.caltech.edu/records/1235"),
     "https://doi.org/10.21105/joss.01277": (
         "https://joss.theoj.org/papers/10.21105/joss.01277"

--- a/tests/unit/contentproviders/test_zenodo.py
+++ b/tests/unit/contentproviders/test_zenodo.py
@@ -14,7 +14,9 @@ from repo2docker.contentproviders import Zenodo
 
 doi_responses = {
     "https://doi.org/10.5281/zenodo.3232985": ("https://zenodo.org/record/3232985"),
-    "https://doi.org/10.5281/zenodo.18553140": ("https://zenodo.org/doi/10.5281/zenodo.18553140"),
+    "https://doi.org/10.5281/zenodo.18553140": (
+        "https://zenodo.org/doi/10.5281/zenodo.18553140"
+    ),
     "https://doi.org/10.22002/d1.1235": ("https://data.caltech.edu/records/1235"),
     "https://doi.org/10.21105/joss.01277": (
         "https://joss.theoj.org/papers/10.21105/joss.01277"

--- a/tests/unit/contentproviders/test_zenodo.py
+++ b/tests/unit/contentproviders/test_zenodo.py
@@ -32,7 +32,9 @@ test_zen = Zenodo()
 test_hosts = [
     (
         [
+            "https://zenodo.org/records/3232985",
             "https://zenodo.org/record/3232985",
+            "https://zenodo.org/doi/10.5281/zenodo.3232985",
             "10.5281/zenodo.3232985",
             "https://doi.org/10.5281/zenodo.3232985",
         ],
@@ -41,14 +43,18 @@ test_hosts = [
     (
         [
             "https://zenodo.org/records/18553140",
+            "https://zenodo.org/record/18553140",
+            "https://zenodo.org/doi/10.5281/zenodo.18553140",
             "10.5281/zenodo.18553140",
             "https://doi.org/10.5281/zenodo.18553140",
         ],
-        {"host": test_zen.hosts[1], "record": "zenodo.18553140"},
+        {"host": test_zen.hosts[1], "record": "18553140"},
     ),
     (
         [
             "https://data.caltech.edu/records/1235",
+            # data.caltech.edu was stripped of the endpoint /record/
+            # data.caltech.edu was stripped of the endpoint /doi/
             "10.22002/d1.1235",
             "https://doi.org/10.22002/d1.1235",
         ],
@@ -60,9 +66,8 @@ test_hosts = [
 @pytest.mark.parametrize("test_input,expected", test_hosts)
 def test_detect_zenodo(test_input, expected):
     # valid Zenodo DOIs trigger this content provider
-    assert Zenodo().detect(test_input[0]) == expected
-    assert Zenodo().detect(test_input[1]) == expected
-    assert Zenodo().detect(test_input[2]) == expected
+    for str_input in test_input:
+        assert Zenodo().detect(str_input) == expected
 
     # Don't trigger the Zenodo content provider
     assert Zenodo().detect("/some/path/here") is None


### PR DESCRIPTION
As reported in https://github.com/jupyterhub/repo2docker/issues/1503, the content provider for Zenodo is not working as expected. I believe there were some changes in the Zenodo API but I could not find a reference to the changes.

The first change is that the URL in the `hostname` was `https://zenodo.org/doi/` instead of `https://zenodo.org/records/`.

The second change is that the record ID was `18553140` instead of `zenodo.18553140`.

## Before this pull request

```
$ repo2docker --no-build --debug 10.5281/zenodo.18553140
[Repo2Docker] Looking for repo2docker_config in /home/raniere/github.com/jupyterhub/repo2docker
Retrieving dataverse installations from https://iqss.github.io/dataverse-installations/data/data.jsonTraceback (most recent call last):
  File "/home/raniere/github.com/jupyterhub/repo2docker/.pixi/envs/default/bin/repo2docker", line 7, in <module>
    sys.exit(main())
             ~~~~^^
  File "/home/raniere/github.com/jupyterhub/repo2docker/repo2docker/__main__.py", line 476, in main
    r2d.start()
    ~~~~~~~~~^^
  File "/home/raniere/github.com/jupyterhub/repo2docker/repo2docker/app.py", line 850, in start
    self.build()
    ~~~~~~~~~~^^
  File "/home/raniere/github.com/jupyterhub/repo2docker/repo2docker/app.py", line 738, in build
    self.fetch(self.repo, self.ref, checkout_path)
    ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/raniere/github.com/jupyterhub/repo2docker/repo2docker/app.py", line 503, in fetch
    spec = cp.detect(url, ref=ref)
  File "/home/raniere/github.com/jupyterhub/repo2docker/repo2docker/contentproviders/mercurial.py", line 16, in detect
    subprocess.check_output(
    ~~~~~~~~~~~~~~~~~~~~~~~^
        ["hg", "identify", source, "--config", "extensions.hggit=!"]
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        + args_enabling_topic,
        ^^^^^^^^^^^^^^^^^^^^^^
        stderr=subprocess.DEVNULL,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/home/raniere/github.com/jupyterhub/repo2docker/.pixi/envs/default/lib/python3.13/subprocess.py", line 472, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
           ~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
               **kwargs).stdout
               ^^^^^^^^^
  File "/home/raniere/github.com/jupyterhub/repo2docker/.pixi/envs/default/lib/python3.13/subprocess.py", line 554, in run
    with Popen(*popenargs, **kwargs) as process:
         ~~~~~^^^^^^^^^^^^^^^^^^^^^^
  File "/home/raniere/github.com/jupyterhub/repo2docker/.pixi/envs/default/lib/python3.13/subprocess.py", line 1039, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
    ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                        pass_fds, cwd, env,
                        ^^^^^^^^^^^^^^^^^^^
    ...<5 lines>...
                        gid, gids, uid, umask,
                        ^^^^^^^^^^^^^^^^^^^^^^
                        start_new_session, process_group)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/raniere/github.com/jupyterhub/repo2docker/.pixi/envs/default/lib/python3.13/subprocess.py", line 1972, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: 'hg'
```

## After this pull request

```
$ repo2docker --no-build --debug 10.5281/zenodo.18553140
[Repo2Docker] Looking for repo2docker_config in /home/raniere/github.com/jupyterhub/repo2docker
Picked Zenodo content provider.
Fetching Zenodo record 18553140.
Fetching Zenodo record 18553140 files.
Downloading file https://zenodo.org/api/records/18553140/files/InsightSoftwareConsortium/ITKElastix-v0.24.0.zip/content as InsightSoftwareConsortium/ITKElastix-v0.24.0.zip
Requesting https://zenodo.org/api/records/18553140/files/InsightSoftwareConsortium/ITKElastix-v0.24.0.zip/content
Creating /tmp/repo2dockerp35_7xyk/InsightSoftwareConsortium
Fetching InsightSoftwareConsortium/ITKElastix-v0.24.0.zip
...
```

## Next steps

- [ ] @manics could you review this pull request?