### PR TITLE
try to fix dependabot for Dockerfile

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -13,6 +13,13 @@ updates:
     labels: [ci]
     schedule:
       interval: monthly
+    cooldown:
+      default-days: 7
+    groups:
+      actions:
+        patterns:
+          - "*"
+
   # Update frozen requirements in repo2docker Dockerfile
   - package-ecosystem: pip
     directory: /
@@ -21,5 +28,11 @@ updates:
       # otherwise only direct dependencies in requirements.in will be updated
       - dependency-type: all
     labels: [dependencies]
+    groups:
+      dockerfile:
+        patterns:
+          - "*"
     schedule:
       interval: monthly
+    cooldown:
+      default-days: 7

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN cd /tmp/src && git clean -xfd && git status
 RUN mkdir /tmp/wheelhouse \
  && cd /tmp/wheelhouse \
  && pip install wheel \
- && pip wheel --no-cache-dir -r /tmp/src/requirements.txt \
+ && pip wheel --no-cache-dir -r /tmp/src/requirements.txt /tmp/src \
  && ls -l /tmp/wheelhouse
 
 FROM alpine:${ALPINE_VERSION}

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,8 +22,6 @@ iso8601==2.1.0
     # via jupyter-repo2docker
 jinja2==3.1.6
     # via jupyter-repo2docker
-jupyter-repo2docker @ file:///tmp/src
-    # via -r requirements.in
 markupsafe==3.0.3
     # via jinja2
 packaging==26.0
@@ -46,3 +44,6 @@ urllib3==2.6.3
     # via
     #   docker
     #   requests
+
+# The following packages are considered to be unsafe in a requirements file:
+# jupyter-repo2docker

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@
 #
 certifi==2026.2.25
     # via requests
-charset-normalizer==3.4.5
+charset-normalizer==3.4.7
     # via
     #   jupyter-repo2docker
     #   requests
@@ -24,11 +24,11 @@ jinja2==3.1.6
     # via jupyter-repo2docker
 markupsafe==3.0.3
     # via jinja2
-packaging==26.0
+packaging==26.1
     # via jupyter-repo2docker
-python-json-logger==4.0.0
+python-json-logger==4.1.0
     # via jupyter-repo2docker
-requests==2.32.5
+requests==2.33.1
     # via
     #   docker
     #   jupyter-repo2docker

--- a/scripts/refreeze
+++ b/scripts/refreeze
@@ -32,6 +32,7 @@ def refreeze():
     """
 
     alpine_version = get_alpine_version()
+
     run(
         [
             "docker",
@@ -48,7 +49,8 @@ def refreeze():
         python3 -m venv /tmp/venv
         source /tmp/venv/bin/activate
         pip install pip-tools
-        pip-compile
+        # exclude repo2docker itself because dependabot messes it up
+        pip-compile --unsafe-package=jupyter-repo2docker
         """,
         ]
     )

--- a/scripts/refreeze
+++ b/scripts/refreeze
@@ -50,7 +50,7 @@ def refreeze():
         source /tmp/venv/bin/activate
         pip install pip-tools
         # exclude repo2docker itself because dependabot messes it up
-        pip-compile --unsafe-package=jupyter-repo2docker
+        pip-compile --upgrade --unsafe-package=jupyter-repo2docker
         """,
         ]
     )

--- a/scripts/refreeze
+++ b/scripts/refreeze
@@ -50,7 +50,7 @@ def refreeze():
         source /tmp/venv/bin/activate
         pip install pip-tools
         # exclude repo2docker itself because dependabot messes it up
-        pip-compile --upgrade --unsafe-package=jupyter-repo2docker
+        pip-compile --upgrade --no-allow-unsafe --unsafe-package=jupyter-repo2docker
         """,
         ]
     )


### PR DESCRIPTION
- exclude repo2docker itself from requirements.txt because dependabot messes with paths (see #1522 and related PRs)
- group dependabot PRs
- apply safer cooldown default
