### PR TITLE
fix figshare url regex

### DIFF
--- a/repo2docker/contentproviders/figshare.py
+++ b/repo2docker/contentproviders/figshare.py
@@ -41,7 +41,9 @@ class Figshare(DoiProvider):
     # We may need to add other item types in future, see
     # https://github.com/jupyterhub/repo2docker/pull/1001#issuecomment-760107436
     # for a list
-    url_regex = re.compile(r"(.*)/articles/(code/|dataset/)?([^/]+)/(\d+)(/)?(\d+)?")
+    url_regex = re.compile(
+        r"(.*)/articles/(code/|dataset/|software/)?([^/]+)/(\d+)(/)?(\d+)?"
+    )
 
     def detect(self, doi, ref=None, extra_args=None):
         """Trigger this provider for things that resolve to a Figshare article"""


### PR DESCRIPTION
software is a valid category

this is fragile and other categories can also fail

binderhub had a different fix, which also correctly handles unspecified versions (unlike this). I don't want to change this too much, since I think we should be moving to repoproviders when we can. This unblocks CI failures (and fixes a real figshare resolution bug).

this should fix `unit` failures, #1528 fixes the `ui` failure