### PR TITLE
R: use `remotes::local_install` instead of deprecated `devtools::install_local`

### DIFF
--- a/repo2docker/buildpacks/_r_base.py
+++ b/repo2docker/buildpacks/_r_base.py
@@ -12,7 +12,7 @@ def rstudio_base_scripts(r_version):
 
     # Shiny server (not the package!) seems to be the same version for all R versions
     shiny_server_url = "https://download3.rstudio.org/ubuntu-18.04/x86_64/shiny-server-1.5.22.1017-amd64.deb"
-    shiny_proxy_version = "1.3"
+    shiny_proxy_version = "1.4"
     shiny_sha256sum = "0fa40054f038de464a26f3f8c40180a072228454762b7a12ed50568b3256c236"
 
     # RStudio server has different builds based on wether OpenSSL 3 or 1.1 is available.

--- a/repo2docker/buildpacks/r.py
+++ b/repo2docker/buildpacks/r.py
@@ -415,7 +415,7 @@ class RBuildPack(PythonBuildPack):
             assemble_scripts += [
                 (
                     "${NB_USER}",
-                    'R --no-save --no-restore --no-init-file --no-environ --quiet -e "pak::local_install()"',
+                    'R --no-save --no-restore --no-init-file --no-environ --quiet -e "pak::local_install()" && rm -rf $HOME/.cache/R',
                 )
             ]
 

--- a/repo2docker/buildpacks/r.py
+++ b/repo2docker/buildpacks/r.py
@@ -348,10 +348,10 @@ class RBuildPack(PythonBuildPack):
             ),
             (
                 "${NB_USER}",
-                # Install a pinned version of pak, devtools, IRKernel and shiny
+                # Install a pinned version of remotes, devtools, IRKernel and shiny
                 rf"""
                 export EXPANDED_CRAN_MIRROR_URL="$(. /etc/os-release && echo {cran_mirror_url} | envsubst)" && \
-                R --no-save --no-restore --no-init-file --no-environ --quiet -e "install.packages(c('pak', 'devtools', 'IRkernel', 'shiny'), repos=Sys.getenv(\"EXPANDED_CRAN_MIRROR_URL\"))" && \
+                R --no-save --no-restore --no-init-file --no-environ --quiet -e "install.packages(c('remotes', 'devtools', 'IRkernel', 'shiny'), repos=Sys.getenv(\"EXPANDED_CRAN_MIRROR_URL\"))" && \
                 R --no-save --no-restore --no-init-file --no-environ --quiet -e "IRkernel::installspec(prefix=Sys.getenv(\"NB_PYTHON_PREFIX\"))"
                 """,
             ),
@@ -415,10 +415,7 @@ class RBuildPack(PythonBuildPack):
             assemble_scripts += [
                 (
                     "${NB_USER}",
-                    # pak doesn't seem to cleanup after itself.
-                    # pak::cache_clean() doesn't empty the cache,
-                    # it leaves files in /tmp/Rabc123.../ and ~/.cache/R/pkg/...
-                    'R --no-save --no-restore --no-init-file --no-environ --quiet -e "pak::install_local()"; rm -rf $HOME/.cache/R; rm -rf /tmp/R*',
+                    'R --no-save --no-restore --no-init-file --no-environ --quiet -e "remotes::install_local()"',
                 )
             ]
 

--- a/repo2docker/buildpacks/r.py
+++ b/repo2docker/buildpacks/r.py
@@ -348,10 +348,10 @@ class RBuildPack(PythonBuildPack):
             ),
             (
                 "${NB_USER}",
-                # Install a pinned version of devtools, IRKernel and shiny
+                # Install a pinned version of pak, devtools, IRKernel and shiny
                 rf"""
                 export EXPANDED_CRAN_MIRROR_URL="$(. /etc/os-release && echo {cran_mirror_url} | envsubst)" && \
-                R --no-save --no-restore --no-init-file --no-environ --quiet -e "install.packages(c('devtools', 'IRkernel', 'shiny'), repos=Sys.getenv(\"EXPANDED_CRAN_MIRROR_URL\"))" && \
+                R --no-save --no-restore --no-init-file --no-environ --quiet -e "install.packages(c('pak', 'devtools', 'IRkernel', 'shiny'), repos=Sys.getenv(\"EXPANDED_CRAN_MIRROR_URL\"))" && \
                 R --no-save --no-restore --no-init-file --no-environ --quiet -e "IRkernel::installspec(prefix=Sys.getenv(\"NB_PYTHON_PREFIX\"))"
                 """,
             ),
@@ -415,7 +415,10 @@ class RBuildPack(PythonBuildPack):
             assemble_scripts += [
                 (
                     "${NB_USER}",
-                    'R --no-save --no-restore --no-init-file --no-environ --quiet -e "pak::local_install()" && rm -rf $HOME/.cache/R',
+                    # pak doesn't seem to cleanup after itself.
+                    # pak::cache_clean() doesn't empty the cache,
+                    # it leaves files in /tmp/Rabc123.../ and ~/.cache/R/pkg/...
+                    'R --no-save --no-restore --no-init-file --no-environ --quiet -e "pak::install_local()"; rm -rf $HOME/.cache/R; rm -rf /tmp/R*',
                 )
             ]
 

--- a/repo2docker/buildpacks/r.py
+++ b/repo2docker/buildpacks/r.py
@@ -415,7 +415,7 @@ class RBuildPack(PythonBuildPack):
             assemble_scripts += [
                 (
                     "${NB_USER}",
-                    'R --no-save --no-restore --no-init-file --no-environ --quiet -e "devtools::install_local(getwd())"',
+                    'R --no-save --no-restore --no-init-file --no-environ --quiet -e "pak::local_install()"',
                 )
             ]
 


### PR DESCRIPTION
`devtools::install_local` doesn't work anymore due to missing dependency on `remotes`, and is deprecated since 2.5.0.

We are not using an independently pinned versions of devtools, despite indications in the code that we appear to intend to. I'm not sure if this loss of pinning is intentional, since I'm not an R expert.

I also don't know the possible implications of this change for repos with older versions. This is just the command the deprecation message pointed me to.