### PR TITLE
try excluding docs and dev dependencies from docker dependabot config

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -23,6 +23,11 @@ updates:
   # Update frozen requirements in repo2docker Dockerfile
   - package-ecosystem: pip
     directory: /
+    exclude-paths:
+      # don't apply this config to docs and dev requirements,
+      # which will cause undesired updates
+      - docs/**
+      - dev-requirements.txt
     allow:
       # need this to upgrade requirements.txt
       # otherwise only direct dependencies in requirements.in will be updated


### PR DESCRIPTION
it's opening PRs to bump inappropriately

closes #1532

not sure if this will really work, but hopefully