### PR TITLE
mamba 2.6, conda 26.3.2

### DIFF
--- a/repo2docker/buildpacks/conda/install-base-env.bash
+++ b/repo2docker/buildpacks/conda/install-base-env.bash
@@ -5,8 +5,8 @@ set -ex
 
 cd $(dirname $0)
 
-export MAMBA_VERSION="2.3.3"
-export CONDA_VERSION="25.9.1"
+export MAMBA_VERSION="2.6.0"
+export CONDA_VERSION="26.3.2"
 
 URL="https://anaconda.org/conda-forge/micromamba/${MAMBA_VERSION}/download/${CONDA_PLATFORM}/micromamba-${MAMBA_VERSION}-0.tar.bz2"
 

--- a/tests/conda/py35-binder-dir/verify
+++ b/tests/conda/py35-binder-dir/verify
@@ -15,11 +15,12 @@ out = sh([kernel_python, "--version"], stderr=STDOUT)
 v = out.split()[1]
 assert v[:3] == "3.5", out
 
+mamba_version = "2.6.0"
+
 out = sh(["micromamba", "--version"])
-assert out == "2.3.3", out
+assert out == mamba_version, out
 
 out = sh(["mamba", "--version"])
-assert out == "2.3.3", out
-
+assert out == mamba_version, out
 
 sh([kernel_python, "-c", "import numpy"])

--- a/tests/conda/py36-postBuild/postBuild
+++ b/tests/conda/py36-postBuild/postBuild
@@ -3,7 +3,8 @@ set -ex
 
 # mamba/conda installs in kernel env
 mamba install -y make
+mamba clean --all
 
 # note `pip` on path is _not_ the kernel env!
 # is this what we (or users) want?
-pip install pytest
+pip install --no-cache pytest


### PR DESCRIPTION
tested in #1418 

now stable release

this gets us [sharded repodata](https://conda.org/blog/sharded-repodata-improvements/) which should improve conda solve times.