### PR TITLE
Use "docker push" instead of "docker build --push"

### DIFF
--- a/repo2docker/docker.py
+++ b/repo2docker/docker.py
@@ -164,9 +164,6 @@ class DockerEngine(ContainerEngine):
                 )
             args.append("--load")
 
-        if push:
-            args.append("--push")
-
         if buildargs:
             for k, v in buildargs.items():
                 args += ["--build-arg", f"{k}={v}"]
@@ -207,6 +204,9 @@ class DockerEngine(ContainerEngine):
                 args += [path]
 
                 yield from execute_cmd(args, True)
+
+            if push:
+                yield from execute_cmd([self.container_cli, "push", tag], True)
 
     def inspect_image(self, image):
         """

--- a/repo2docker/docker.py
+++ b/repo2docker/docker.py
@@ -189,8 +189,6 @@ class DockerEngine(ContainerEngine):
         args += self.extra_buildx_build_args
 
         with ExitStack() as stack:
-            if self.registry_credentials:
-                stack.enter_context(self.docker_login(**self.registry_credentials))
             if fileobj:
                 with tempfile.TemporaryDirectory() as d:
                     tarf = tarfile.open(fileobj=fileobj)
@@ -205,7 +203,10 @@ class DockerEngine(ContainerEngine):
 
                 yield from execute_cmd(args, True)
 
-            if push:
+            if push and tag:
+                if self.registry_credentials:
+                    stack.enter_context(self.docker_login(**self.registry_credentials))
+
                 yield from execute_cmd([self.container_cli, "push", tag], True)
 
     def inspect_image(self, image):


### PR DESCRIPTION
This improves `repo2docker` compatibility with Podman.

Closes https://github.com/jupyterhub/repo2docker/issues/1536

@minrk This PR needs a little more work.

- [x] `docker push` needs the correct name of the container image

cc @dylex