### PR TITLE
roll back to mamba 2.5.0

### DIFF
--- a/repo2docker/buildpacks/conda/install-base-env.bash
+++ b/repo2docker/buildpacks/conda/install-base-env.bash
@@ -5,10 +5,12 @@ set -ex
 
 cd $(dirname $0)
 
-export MAMBA_VERSION="2.6.1"
+# mamba version checked in tests/conda/py35-binder-dir/verify
+export MAMBA_VERSION="2.5.0"
 export CONDA_VERSION="26.3.2"
+MICROMAMBA_BUILD=2
 
-URL="https://anaconda.org/conda-forge/micromamba/${MAMBA_VERSION}/download/${CONDA_PLATFORM}/micromamba-${MAMBA_VERSION}-0.tar.bz2"
+URL="https://anaconda.org/conda-forge/micromamba/${MAMBA_VERSION}/download/${CONDA_PLATFORM}/micromamba-${MAMBA_VERSION}-${MICROMAMBA_BUILD}.tar.bz2"
 
 # make sure we don't do anything funky with user's $HOME
 # since this is run as root

--- a/tests/conda/py35-binder-dir/verify
+++ b/tests/conda/py35-binder-dir/verify
@@ -15,7 +15,7 @@ out = sh([kernel_python, "--version"], stderr=STDOUT)
 v = out.split()[1]
 assert v[:3] == "3.5", out
 
-mamba_version = "2.6.1"
+mamba_version = "2.5.0"
 
 out = sh(["micromamba", "--version"])
 assert out == mamba_version, out


### PR DESCRIPTION
2.6.0/2.6.1 seems to introduce some solver regressions leading to unsolvable and/or much slower solves in repo2docker use cases that work better with 2.5 (repo2docker solves are all upgrades of a base env rather than single-env solve&install). 

our existing downgrade test is much slower (15 minutes vs 4), and https://github.com/ecmwf/notebook-examples doesn't seem to complete (https://github.com/jupyterhub/mybinder.org-deploy/issues/3803) which works fine on 2.5.0.

https://github.com/mamba-org/mamba/pull/4270 may fix this, but we should check runtime for our downgrade test and https://github.com/ecmwf/notebook-examples when we try 2.6.2

cc @SylvainCorlay @jjerphan 