### PR TITLE
Quote LABEL key/value in Dockerfile template

### DIFF
--- a/repo2docker/buildpacks/base.py
+++ b/repo2docker/buildpacks/base.py
@@ -4,7 +4,6 @@ import io
 import logging
 import os
 import re
-import shlex
 import string
 import sys
 import tarfile
@@ -16,21 +15,36 @@ import jinja2
 from docker.utils.build import exclude_paths
 
 
-def _quote_dockerfile_token(value):
-    """Quote a label key/value for inclusion in a Dockerfile LABEL directive.
+def _dockerfile_quote(value):
+    """Encode a string as a double-quoted word for a Dockerfile LABEL directive.
 
-    Wraps :func:`shlex.quote` with an explicit escape of backslash, ``\\n`` and
-    ``\\r`` so the result occupies a single Dockerfile directive line.
-    Dockerfile single-quoted strings (which :func:`shlex.quote` produces for
-    values containing shell metacharacters) do not span newlines the way shell
-    does, so a label value containing a literal newline -- e.g., a multi-line
+    A LABEL line is processed in two passes: the parser splits it into words,
+    keeping quotes and escapes verbatim, and the shell lexer then strips the
+    quotes and resolves the escapes. Inside double quotes that lexer unescapes
+    only ``\\``, ``"`` and ``$`` (every other backslash is left alone) and
+    expands ``$VAR``, so escaping exactly those three characters is what makes
+    an arbitrary value survive unchanged.
+
+    A Dockerfile word cannot carry a newline at all: the parser is line
+    oriented and ``\\n`` is not an escape sequence. Newlines are therefore
+    flattened to a literal backslash-n, so that a multi-line value -- e.g. a
     ``git commit`` message piped through ``--Repo2Docker.labels`` in CI --
-    would otherwise break out of the LABEL directive.
+    lands as a single token instead of breaking out of the LABEL directive and
+    injecting further directives.
+
+    Note this assumes the default ``\\`` escape token; the template does not
+    set a ``# escape=`` parser directive.
     """
     if not isinstance(value, str):
         value = str(value)
-    escaped = value.replace("\\", "\\\\").replace("\n", "\\n").replace("\r", "\\r")
-    return shlex.quote(escaped)
+    escaped = (
+        value.replace("\\", "\\\\")
+        .replace('"', '\\"')
+        .replace("$", "\\$")
+        .replace("\n", "\\n")
+        .replace("\r", "\\r")
+    )
+    return f'"{escaped}"'
 
 
 # Only use syntax features supported by Docker 17.09
@@ -197,7 +211,7 @@ COPY --chown={{ user }}:{{ user }} src/ ${REPO_DIR}/
 # Put these at the end, since we don't want to rebuild everything
 # when these change! Did I mention I hate Dockerfile cache semantics?
 {% for k, v in labels|dictsort %}
-LABEL {{ k|sh_quote }}={{ v|sh_quote }}
+LABEL {{ k|dockerfile_quote }}={{ v|dockerfile_quote }}
 {%- endfor %}
 
 # We always want containers to run as non-root
@@ -512,7 +526,7 @@ class BuildPack:
         build_args = build_args or {}
 
         env = jinja2.Environment()
-        env.filters["sh_quote"] = _quote_dockerfile_token
+        env.filters["dockerfile_quote"] = _dockerfile_quote
         t = env.from_string(TEMPLATE)
 
         build_script_directives = []

--- a/repo2docker/buildpacks/base.py
+++ b/repo2docker/buildpacks/base.py
@@ -4,6 +4,7 @@ import io
 import logging
 import os
 import re
+import shlex
 import string
 import sys
 import tarfile
@@ -13,6 +14,24 @@ from functools import lru_cache
 import escapism
 import jinja2
 from docker.utils.build import exclude_paths
+
+
+def _quote_dockerfile_token(value):
+    """Quote a label key/value for inclusion in a Dockerfile LABEL directive.
+
+    Wraps :func:`shlex.quote` with an explicit escape of backslash, ``\\n`` and
+    ``\\r`` so the result occupies a single Dockerfile directive line.
+    Dockerfile single-quoted strings (which :func:`shlex.quote` produces for
+    values containing shell metacharacters) do not span newlines the way shell
+    does, so a label value containing a literal newline -- e.g., a multi-line
+    ``git commit`` message piped through ``--Repo2Docker.labels`` in CI --
+    would otherwise break out of the LABEL directive.
+    """
+    if not isinstance(value, str):
+        value = str(value)
+    escaped = value.replace("\\", "\\\\").replace("\n", "\\n").replace("\r", "\\r")
+    return shlex.quote(escaped)
+
 
 # Only use syntax features supported by Docker 17.09
 TEMPLATE = r"""
@@ -178,7 +197,7 @@ COPY --chown={{ user }}:{{ user }} src/ ${REPO_DIR}/
 # Put these at the end, since we don't want to rebuild everything
 # when these change! Did I mention I hate Dockerfile cache semantics?
 {% for k, v in labels|dictsort %}
-LABEL {{k}}="{{v}}"
+LABEL {{ k|sh_quote }}={{ v|sh_quote }}
 {%- endfor %}
 
 # We always want containers to run as non-root
@@ -492,7 +511,9 @@ class BuildPack:
         """
         build_args = build_args or {}
 
-        t = jinja2.Template(TEMPLATE)
+        env = jinja2.Environment()
+        env.filters["sh_quote"] = _quote_dockerfile_token
+        t = env.from_string(TEMPLATE)
 
         build_script_directives = []
         last_user = "root"

--- a/tests/unit/test_buildpack.py
+++ b/tests/unit/test_buildpack.py
@@ -1,3 +1,4 @@
+import re
 from datetime import date
 from os.path import join as pjoin
 from tempfile import TemporaryDirectory
@@ -95,51 +96,94 @@ def test_invalid_runtime(tmpdir, runtime_txt, base_image):
         base.runtime
 
 
+# A Dockerfile double-quoted word: any char except a quote or a backslash, or
+# a backslash followed by anything.
+_LABEL_LINE = re.compile(r'^LABEL ("(?:[^"\\]|\\.)*")=("(?:[^"\\]|\\.)*")$')
+
+
+def _unquote_dockerfile_word(word):
+    """Decode a double-quoted Dockerfile word the way the builder does.
+
+    Mirrors ``processDoubleQuote`` in BuildKit's ``frontend/dockerfile/shell``
+    (and its identical ancestor in the Docker 17.09 classic builder): only
+    ``\\``, ``"`` and ``$`` can be escaped, every other backslash is literal.
+    """
+    assert word.startswith('"') and word.endswith('"'), word
+    body = word[1:-1]
+    out = []
+    i = 0
+    while i < len(body):
+        if body[i] == "\\" and i + 1 < len(body) and body[i + 1] in '"$\\':
+            out.append(body[i + 1])
+            i += 2
+        else:
+            out.append(body[i])
+            i += 1
+    return "".join(out)
+
+
 @pytest.mark.parametrize(
-    "label_value",
+    "label_value, expected",
     [
-        "hello\nRUN echo pwned",
-        'value with "double" quotes',
-        "backtick `$(id)` and $VAR",
-        "semicolon; pipe | newline\nstill same value",
+        # Injection attempts: a newline is not representable in a Dockerfile
+        # word, so it is flattened rather than allowed to start a directive.
+        ("hello\nRUN echo pwned", "hello\\nRUN echo pwned"),
+        (
+            "semicolon; pipe | newline\nstill same value",
+            "semicolon; pipe | newline\\nstill same value",
+        ),
+        ('" ; RUN echo pwned ; LABEL x="', '" ; RUN echo pwned ; LABEL x="'),
+        # Values that must survive byte for byte.
+        ('value with "double" quotes', None),
+        ("backtick `$(id)` and $VAR", None),
+        (r"windows\path\to\file", None),
+        ("trailing backslash\\", None),
+        ("", None),
+        ("héllo 中文 🎉", None),
     ],
 )
 def test_labels_with_special_chars_do_not_break_dockerfile(
-    tmpdir, label_value, base_image
+    tmpdir, label_value, expected, base_image
 ):
-    """Operator-supplied label values containing newlines, quotes, or shell
-    metacharacters must not introduce extra Dockerfile directives.
+    """Label values must land as exactly one token, decoding back unchanged.
 
-    The previous template rendered ``LABEL k="{{v}}"`` with no escaping, so a
-    value containing a literal newline followed by ``RUN ...`` produced a real
-    Dockerfile RUN directive at build time. Apply ``shlex.quote`` to both key
-    and value so that the value lands as a single quoted token regardless of
-    its contents.
+    The template used to render ``LABEL k="{{v}}"`` with no escaping at all, so
+    a value containing a literal newline followed by ``RUN ...`` became a real
+    Dockerfile RUN directive at build time.
+
+    ``expected`` is the value after decoding; ``None`` means it must round-trip
+    unchanged. Newlines cannot be represented and are flattened to a literal
+    backslash-n, which is the one lossy case.
     """
+    if expected is None:
+        expected = label_value
+
     tmpdir.chdir()
     bp = BaseImage(base_image)
     bp.labels = {"my.label": label_value}
     dockerfile = bp.render()
 
-    # Find the single LABEL directive that carries our key.
     label_lines = [
-        line
-        for line in dockerfile.splitlines()
-        if line.startswith("LABEL ") and "my.label" in line
+        line for line in dockerfile.splitlines() if line.startswith("LABEL ")
     ]
     assert len(label_lines) == 1, (
-        f"expected exactly one LABEL line for my.label, found "
-        f"{len(label_lines)}: {label_lines!r}"
+        f"expected exactly one LABEL line, found {len(label_lines)}: "
+        f"{label_lines!r}"
     )
 
-    # No subsequent top-level directive should appear that wasn't there
-    # before. In particular, no `RUN echo pwned` injected as its own line.
-    top_level_runs = [
+    # The value must not have broken out and started a directive of its own.
+    assert not [
         line
         for line in dockerfile.splitlines()
         if line.startswith("RUN ") and "pwned" in line
-    ]
-    assert not top_level_runs, (
-        f"label value broke out of LABEL directive and produced an extra "
-        f"top-level RUN: {top_level_runs!r}"
-    )
+    ], f"label value injected a top-level RUN:\n{dockerfile}"
+
+    match = _LABEL_LINE.match(label_lines[0])
+    assert match, f"LABEL line is not two quoted words: {label_lines[0]!r}"
+    key, value = match.groups()
+
+    # An unescaped $ would be substituted from the build environment.
+    assert "$" not in re.sub(r"\\.", "", value), f"unescaped $ in {value!r}"
+
+    assert _unquote_dockerfile_word(key) == "my.label"
+    assert _unquote_dockerfile_word(value) == expected

--- a/tests/unit/test_buildpack.py
+++ b/tests/unit/test_buildpack.py
@@ -93,3 +93,53 @@ def test_invalid_runtime(tmpdir, runtime_txt, base_image):
 
     with pytest.raises(ValueError, match=r"^Invalid runtime.txt.*"):
         base.runtime
+
+
+@pytest.mark.parametrize(
+    "label_value",
+    [
+        "hello\nRUN echo pwned",
+        'value with "double" quotes',
+        "backtick `$(id)` and $VAR",
+        "semicolon; pipe | newline\nstill same value",
+    ],
+)
+def test_labels_with_special_chars_do_not_break_dockerfile(
+    tmpdir, label_value, base_image
+):
+    """Operator-supplied label values containing newlines, quotes, or shell
+    metacharacters must not introduce extra Dockerfile directives.
+
+    The previous template rendered ``LABEL k="{{v}}"`` with no escaping, so a
+    value containing a literal newline followed by ``RUN ...`` produced a real
+    Dockerfile RUN directive at build time. Apply ``shlex.quote`` to both key
+    and value so that the value lands as a single quoted token regardless of
+    its contents.
+    """
+    tmpdir.chdir()
+    bp = BaseImage(base_image)
+    bp.labels = {"my.label": label_value}
+    dockerfile = bp.render()
+
+    # Find the single LABEL directive that carries our key.
+    label_lines = [
+        line
+        for line in dockerfile.splitlines()
+        if line.startswith("LABEL ") and "my.label" in line
+    ]
+    assert len(label_lines) == 1, (
+        f"expected exactly one LABEL line for my.label, found "
+        f"{len(label_lines)}: {label_lines!r}"
+    )
+
+    # No subsequent top-level directive should appear that wasn't there
+    # before. In particular, no `RUN echo pwned` injected as its own line.
+    top_level_runs = [
+        line
+        for line in dockerfile.splitlines()
+        if line.startswith("RUN ") and "pwned" in line
+    ]
+    assert not top_level_runs, (
+        f"label value broke out of LABEL directive and produced an extra "
+        f"top-level RUN: {top_level_runs!r}"
+    )

--- a/tests/unit/test_labels.py
+++ b/tests/unit/test_labels.py
@@ -16,10 +16,12 @@ URL = "https://github.com/binderhub-ci-repos/repo2docker-ci-clone-depth"
 def test_buildpack_labels_rendered(base_image):
     bp = BuildPack(base_image)
     assert "LABEL" not in bp.render()
+    # Keys are quoted too, so that a key containing whitespace or a Dockerfile
+    # metacharacter cannot start a directive of its own.
     bp.labels["first_label"] = "firstlabel"
-    assert 'LABEL first_label="firstlabel"\n' in bp.render()
+    assert 'LABEL "first_label"="firstlabel"\n' in bp.render()
     bp.labels["second_label"] = "anotherlabel"
-    assert 'LABEL second_label="anotherlabel"\n' in bp.render()
+    assert 'LABEL "second_label"="anotherlabel"\n' in bp.render()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Adds quoting on the LABEL key/value interpolation in `repo2docker/buildpacks/base.py` so that newlines, double-quotes, or shell metacharacters in operator-supplied label values (`--Repo2Docker.labels` / `Repo2Docker(labels=...)`) don't break the generated Dockerfile.

The template used to render:

```jinja
LABEL {{k}}="{{v}}"
```

with no escaping. A realistic break-the-build case is a CI pipeline that passes `git log -1 --pretty=%B` into a label — a multi-line commit message produces a Dockerfile that no longer parses.

This is not a vulnerability — repo2docker trusts the operator who configures the CLI flag — but the quoting cleanup was suggested by @minrk in the discussion of [GHSA-pv57-6gv8-cc38](https://github.com/jupyterhub/repo2docker/security/advisories/GHSA-pv57-6gv8-cc38):

> "no vulnerabilities here, but quoting on labels should be improved. A PR would be welcome adding shlex.quote to labels"

## Approach

The first revision of this PR used `shlex.quote`, as suggested. On closer inspection that turned out to be the wrong tool, so this now uses Dockerfile quoting instead. `shlex.quote` produces *shell* quoting, but a LABEL directive is never parsed by a shell — it goes through the Dockerfile parser and then the builder's own lexer, which has different rules. Three concrete problems:

1. **Backslashes were doubled.** `shlex.quote` single-quotes anything containing a metacharacter, and inside Dockerfile single quotes *no escape processing happens at all* (`processSingleQuote` has no escape branch). So the `\` → `\\` escaping applied before quoting reached the image verbatim: a value of `windows\path` landed as `windows\\path`.
2. **`$VAR` expansion was silently turned off.** LABEL is in `replaceEnvAllowed`, so `LABEL k="$FOO"` expands today. Single-quoting suppresses that — a quiet behaviour change for any value containing a dollar sign.
3. **Keys could stop being keys.** `shlex.quote` returns "safe" strings unquoted, so a key like `--flag` rendered as `LABEL --flag=...`, which buildx rejects as an unknown flag.

Instead, both key and value are now encoded as a Dockerfile double-quoted word:

```python
def _dockerfile_quote(value):
    if not isinstance(value, str):
        value = str(value)
    escaped = (
        value.replace("\\", "\\\\")
        .replace('"', '\\"')
        .replace("$", "\\$")
        .replace("\n", "\\n")
        .replace("\r", "\\r")
    )
    return f'"{escaped}"'
```

Per `processDoubleQuote` in BuildKit's `frontend/dockerfile/shell/lex.go` — and the byte-for-byte identical function in the Docker 17.09 classic builder, which the template comment still targets — that lexer unescapes **only** `\`, `"` and `$`:

```go
case '"', '$', sw.escapeToken:
    // These chars can be escaped, all other \'s are left as-is
```

So escaping exactly those three characters is necessary and sufficient for an arbitrary value to round-trip unchanged.

Rendered output for a typical label is unremarkable:

```dockerfile
LABEL "org.opencontainers.image.source"="https://github.com/foo/bar"
```

## Known limitations

- **Newlines are lossy.** A Dockerfile word cannot carry a newline: the parser is line-oriented, `\n` is not an escape sequence, and heredocs aren't permitted on LABEL. Newlines are flattened to a literal backslash-n. That is still the point of the PR — a multi-line commit message lands as one token instead of injecting a `RUN` — but the value is not byte-identical. The only way to preserve a real newline would be to pass labels out of band via the build API, as `DockerBuildPack` already does (`labels=self.get_labels()` in `buildpacks/docker.py`). Happy to do that as a follow-up if you'd prefer it to escaping.
- **A key containing `=` is unrepresentable.** `parseNameVal` splits on the first `=` of the *raw, still-quoted* word, so no amount of quoting helps. Previously this corrupted silently (key `a`, value `b=...`); now it fails loudly at build time.
- The encoding assumes the default `\` escape token; the template sets no `# escape=` directive.

## Changes

- `repo2docker/buildpacks/base.py`
  - new `_dockerfile_quote` helper (replaces `_quote_dockerfile_token`; the `shlex` import is gone again)
  - `render()` constructs a `jinja2.Environment` with a `dockerfile_quote` filter wired in (replacing `jinja2.Template(TEMPLATE)`)
  - the LABEL line in `TEMPLATE` applies it to both key and value
- `tests/unit/test_buildpack.py` — parametrised regression test that now asserts the **decoded** value, not just the absence of an injected directive. It includes a reference implementation of `processDoubleQuote` so the expected semantics are written down next to the assertions. Cases: newline injection, `" ; RUN echo pwned ; LABEL x="`, embedded double quotes, backtick + `$VAR`, Windows paths, trailing backslash, empty string, non-ASCII.
- `tests/unit/test_labels.py` — expectations updated for the new `LABEL "k"="v"` shape (keys are quoted too, so a key containing whitespace can't start a directive of its own).

## Test plan

- [x] `pytest tests/unit/test_buildpack.py tests/unit/test_labels.py` → 28 passed
- [x] Full `tests/unit` run: failure set is identical to the pre-PR baseline, i.e. this branch introduces no new failures
- [x] Fuzzed 20k random values (quotes, backslashes, `$`, backticks, tabs, CR, newlines, non-ASCII) through the **real BuildKit parser** via the `dockerfile` Python bindings, decoding with the lexer rules above — 20000/20000 round-trip exactly, modulo the documented newline flattening
- [x] `pyupgrade` / `isort` / `black` clean

Refs: https://github.com/jupyterhub/repo2docker/security/advisories/GHSA-pv57-6gv8-cc38

🤖 Generated with [Claude Code](https://claude.com/claude-code)
