### PR TITLE
Fix problem with built-in terminal in RStudio

### DIFF
--- a/repo2docker/buildpacks/conda/__init__.py
+++ b/repo2docker/buildpacks/conda/__init__.py
@@ -454,6 +454,7 @@ class CondaBuildPack(BaseImage):
                 (
                     "root",
                     rf"""
+                    echo export CONDA_DIR="/srv/conda" >> /etc/profile.d/00-rstudio.sh && \
                     echo auth-none=1 >> /etc/rstudio/rserver.conf && \
                     echo auth-minimum-user-id=0 >> /etc/rstudio/rserver.conf && \
                     echo "rsession-which-r={env_prefix}/bin/R" >> /etc/rstudio/rserver.conf && \


### PR DESCRIPTION
Closes https://github.com/jupyterhub/repo2docker/issues/1560

This creates a new file `/etc/profile.d/00-rstudio.sh` when RStudio is being configured.

Is `/etc/profile.d/00-rstudio.sh` is executed before `/etc/profile.d/activate-conda.sh` making `CONDA_DIR` available in the case that RStudio does not load other environment variables.

# Acknowledge

Big thanks to [David Schoch](https://mr.schochastics.net/) and the [cynkra](https://www.cynkra.com/) team for the exchange of ideas related with RStudio Server.