### PR TITLE
Improve activate-conda.sh to not kill shell

### DIFF
--- a/repo2docker/buildpacks/conda/activate-conda.sh
+++ b/repo2docker/buildpacks/conda/activate-conda.sh
@@ -1,38 +1,44 @@
-set -e
-
-# Setup conda
 CONDA_PROFILE="${CONDA_DIR}/etc/profile.d/conda.sh"
-echo "Activating profile: ${CONDA_PROFILE}"
-test -f $CONDA_PROFILE && . $CONDA_PROFILE
 
-# Setup micromamba
-eval $(micromamba shell hook -s posix -r ${CONDA_DIR})
+if [ -f $CONDA_PROFILE ]; then
+    # Setup conda
+    echo "Activating profile: ${CONDA_PROFILE}"
+    source $CONDA_PROFILE
 
-# Setup mamba
-export MAMBA_ROOT_PREFIX="${CONDA_DIR}"
-__mamba_setup="$("${CONDA_DIR}/bin/mamba" shell hook --shell posix 2> /dev/null)"
-if [ $? -eq 0 ]; then
-    eval "$__mamba_setup"
+    # Setup micromamba
+    eval $(micromamba shell hook -s posix -r ${CONDA_DIR})
+
+    # Setup mamba
+    export MAMBA_ROOT_PREFIX="${CONDA_DIR}"
+    __mamba_setup="$("${CONDA_DIR}/bin/mamba" shell hook --shell posix 2> /dev/null)"
+    if [ $? -eq 0 ]; then
+        eval "$__mamba_setup"
+    else
+        alias mamba="${CONDA_DIR}/bin/mamba"  # Fallback on help from mamba activate
+    fi
+    unset __mamba_setup
+
+    # Activate the environment
+    if [[ "${KERNEL_PYTHON_PREFIX}" != "${NB_PYTHON_PREFIX}" ]]; then
+        # if the kernel is a separate env, stack them
+        # so both are on PATH, notebook first
+        mamba activate ${KERNEL_PYTHON_PREFIX}
+        mamba activate --stack ${NB_PYTHON_PREFIX}
+
+        # even though it's second on $PATH
+        # make sure CONDA_DEFAULT_ENV is the *kernel* env
+        # so that `!conda install PKG` installs in the kernel env
+        # where user packages are installed, not the notebook env
+        # which only contains UI when the two are different
+        export CONDA_DEFAULT_ENV="${KERNEL_PYTHON_PREFIX}"
+    else
+        mamba activate ${NB_PYTHON_PREFIX}
+    fi
+
 else
-    alias mamba="${CONDA_DIR}/bin/mamba"  # Fallback on help from mamba activate
+    echo "Conda compatible environment not loaded due to"
+    echo
+    echo "- Mising file ${CONDA_PROFILE}"
+    echo
+    echo "Some tools might NOT be available!"
 fi
-unset __mamba_setup
-
-# Activate the environment
-if [[ "${KERNEL_PYTHON_PREFIX}" != "${NB_PYTHON_PREFIX}" ]]; then
-    # if the kernel is a separate env, stack them
-    # so both are on PATH, notebook first
-    mamba activate ${KERNEL_PYTHON_PREFIX}
-    mamba activate --stack ${NB_PYTHON_PREFIX}
-
-    # even though it's second on $PATH
-    # make sure CONDA_DEFAULT_ENV is the *kernel* env
-    # so that `!conda install PKG` installs in the kernel env
-    # where user packages are installed, not the notebook env
-    # which only contains UI when the two are different
-    export CONDA_DEFAULT_ENV="${KERNEL_PYTHON_PREFIX}"
-else
-    mamba activate ${NB_PYTHON_PREFIX}
-fi
-
-set +e


### PR DESCRIPTION
Related to https://github.com/jupyterhub/repo2docker/issues/1560

This is a supplement to https://github.com/jupyterhub/repo2docker/pull/1563.

In RStudio Server, user now finds a working terminal.

<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/407a72a4-e44d-4c81-8db1-95abdacfcfd6" />

Although `/srv/conda/etc/profile.d/conda.sh` is not being sourced, `/srv/conda/envs/notebook/bin/` is part of the `PATH`.

The built-in terminal in Jupyter works as before

<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/22ad766e-26a8-4798-9d63-d8d00fe7a294" />